### PR TITLE
Core functionalities fix.

### DIFF
--- a/DotNut/Api/CashuHttpClient.cs
+++ b/DotNut/Api/CashuHttpClient.cs
@@ -68,6 +68,13 @@ public class CashuHttpClient : ICashuApi
         return await HandleResponse<TResponse>(response, cancellationToken);
     }
 
+    public async Task<TResponse> CheckMeltQuote<TResponse>(string method, string quoteId, CancellationToken
+        cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync($"v1/melt/quote/{method}/{quoteId}", cancellationToken);
+        return await HandleResponse<TResponse>(response, cancellationToken);
+    }
+
     public async Task<TResponse> CheckMintQuote<TResponse>(string method, string quoteId, CancellationToken
         cancellationToken = default)
     {

--- a/DotNut/Api/CashuHttpClient.cs
+++ b/DotNut/Api/CashuHttpClient.cs
@@ -29,11 +29,11 @@ public class CashuHttpClient : ICashuApi
         return await HandleResponse<GetKeysetsResponse>(response, cancellationToken);
     }
 
-    public async Task<GetKeysetsResponse> GetKeys(KeysetId keysetId, CancellationToken cancellationToken = default)
+    public async Task<GetKeysResponse> GetKeys(KeysetId keysetId, CancellationToken cancellationToken = default)
 
     {
         var response = await _httpClient.GetAsync($"v1/keys/{keysetId}", cancellationToken);
-        return await HandleResponse<GetKeysetsResponse>(response, cancellationToken);
+        return await HandleResponse<GetKeysResponse>(response, cancellationToken);
     }
 
     public async Task<PostSwapResponse> Swap(PostSwapRequest request, CancellationToken cancellationToken = default)

--- a/DotNut/Api/ICashuApi.cs
+++ b/DotNut/Api/ICashuApi.cs
@@ -5,7 +5,7 @@ namespace DotNut.Api;
 public interface ICashuApi
 {
     Task<GetKeysResponse> GetKeys(CancellationToken cancellationToken = default);
-    Task<GetKeysetsResponse> GetKeys(KeysetId keysetId, CancellationToken cancellationToken = default);
+    Task<GetKeysResponse> GetKeys(KeysetId keysetId, CancellationToken cancellationToken = default);
     Task<GetKeysetsResponse> GetKeysets(CancellationToken cancellationToken = default);
     Task<PostSwapResponse> Swap(PostSwapRequest request, CancellationToken cancellationToken = default);
 

--- a/DotNut/ApiModels/GetInfoResponse.cs
+++ b/DotNut/ApiModels/GetInfoResponse.cs
@@ -33,16 +33,23 @@ public class GetInfoResponse
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("motd")]
     public string? Motd { get; set; }
-
-
+    
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("icon_url")]
     public string? IconUrl { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("urls")]
+    public string[]? Urls { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonConverter(typeof(UnixDateTimeOffsetConverter))]
     [JsonPropertyName("time")]
     public DateTimeOffset? Time { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
+    [JsonPropertyName("tos_url")]
+    public string? TosUrl { get; set; }
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("nuts")]

--- a/DotNut/ApiModels/Mint/PostMintQuoteBolt11Request.cs
+++ b/DotNut/ApiModels/Mint/PostMintQuoteBolt11Request.cs
@@ -12,6 +12,7 @@ public class PostMintQuoteBolt11Request
     [JsonPropertyName("unit")] 
     public string Unit {get; set;}
     
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingDefault)]
     [JsonPropertyName("description")] 
     public string? Description {get; set;}
 }

--- a/DotNut/ApiModels/Mint/PostMintQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Mint/PostMintQuoteBolt11Response.cs
@@ -15,4 +15,13 @@ public class PostMintQuoteBolt11Response
     
     [JsonPropertyName("expiry")] 
     public int Expiry { get; set; }
+    
+    // 'amount' and 'unit' were recently added to the spec in PostMintQuoteBolt11Response, so they are optional for now
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("amount")]
+    public int? Amount { get; set; }
+    
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("unit")]
+    public string? Unit {get; set;}
 }

--- a/DotNut/Cashu.cs
+++ b/DotNut/Cashu.cs
@@ -122,7 +122,8 @@ public static class Cashu
 
     public static ECPubKey ComputeC(ECPubKey C_, ECPrivKey r, ECPubKey A)
     {
-        return C_.Q.ToGroupElementJacobian().Add((A.Q * r.sec).ToGroupElement()).ToPubkey();
+        //C_ - rA = C
+        return C_.Q.ToGroupElementJacobian().Add((A.Q * r.sec).ToGroupElement().Negate()).ToPubkey();
     }
 
     private static byte[] Concat(params byte[][] arrays)


### PR DESCRIPTION
This PR addresses several bugs and introduces updates based on issues encountered while using the project:

🔧 Fixes & Improvements

1. Corrected Cashu.ComputeC function logic 
The previous implementation mistakenly re-blinded the signature using C_ + rA = C, instead of properly unblinding it with C = C_ - rA. This could cause major issues such as:
- Mints being unable to verify proofs
- Potential cryptographic vulnerabilities
Reference: [gist with detailed explanation](https://gist.github.com/lollerfirst/13d6ec62e41a0c8743e66b912c506b47)

2. Updated API models
Adjusted the API model classes to reflect recent changes in the Cashu Nuts specification (notably Nut04 and Nut06).

3. Melt quote state check support
Added handling for melt quote state checking to support newer workflows.

4. Return type change for GetKeys method
Modified the return type of the GetKeys method 






