### PR TITLE
Quick Fixes

### DIFF
--- a/DotNut.Tests/UnitTest1.cs
+++ b/DotNut.Tests/UnitTest1.cs
@@ -71,7 +71,7 @@ public class UnitTest1
         Assert.Equal(2, token.Proofs.Count);
         Assert.Collection(token.Proofs, proof =>
             {
-                Assert.Equal(2, proof.Amount);
+                Assert.Equal((ulong)2, proof.Amount);
                 Assert.Equal(new KeysetId("009a1f293253e41e"), proof.Id);
 
                 Assert.Equal("407915bc212be61a77e3e6d2aeb4c727980bda51cd06a6afc29e2861768a7837",
@@ -80,7 +80,7 @@ public class UnitTest1
                     (ECPubKey) proof.C);
             }, proof =>
             {
-                Assert.Equal(8, proof.Amount);
+                Assert.Equal((ulong)8, proof.Amount);
                 Assert.Equal(new KeysetId("009a1f293253e41e"), proof.Id);
                 Assert.Equal("fe15109314e61d7756b0f8ee0f23a624acaa3f4e042f61433c728c7057b931be",
                     Assert.IsType<StringSecret>(proof.Secret).Secret);
@@ -113,7 +113,7 @@ public class UnitTest1
         Assert.Equal(3, token.Proofs.Count);
         Assert.Collection(token.Proofs, proof =>
             {
-                Assert.Equal(1, proof.Amount);
+                Assert.Equal((ulong)1, proof.Amount);
                 Assert.Equal(new KeysetId("00ffd48b8f5ecf80"), proof.Id);
 
                 Assert.Equal("acc12435e7b8484c3cf1850149218af90f716a52bf4a5ed347e48ecc13f77388",
@@ -122,7 +122,7 @@ public class UnitTest1
                     (ECPubKey) proof.C);
             }, proof =>
             {
-                Assert.Equal(2, proof.Amount);
+                Assert.Equal((ulong)2, proof.Amount);
                 Assert.Equal(new KeysetId("00ad268c4d1f5826"), proof.Id);
                 Assert.Equal("1323d3d4707a58ad2e23ada4e9f1f49f5a5b4ac7b708eb0d61f738f48307e8ee",
                     Assert.IsType<StringSecret>(proof.Secret).Secret);
@@ -130,7 +130,7 @@ public class UnitTest1
                     (ECPubKey) proof.C);
             }, proof =>
             {
-                Assert.Equal(1, proof.Amount);
+                Assert.Equal((ulong)1, proof.Amount);
                 Assert.Equal(new KeysetId("00ad268c4d1f5826"), proof.Id);
                 Assert.Equal("56bcbcbb7cc6406b3fa5d57d2174f4eff8b4402b176926d3a57d3c3dcbb59d57",
                     Assert.IsType<StringSecret>(proof.Secret).Secret);
@@ -181,11 +181,14 @@ public class UnitTest1
         var a = "0000000000000000000000000000000000000000000000000000000000000001".ToPrivKey();
         var A = a.CreatePubKey();
         Assert.Equal("0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798".ToPubKey(), A);
-        var message = "secret_msg";
+        var message = new StringSecret("secret_msg");
         var blindingFactor = "0000000000000000000000000000000000000000000000000000000000000001".ToPrivKey();
-        var Y = Cashu.MessageToCurve(message);
+        // var Y = Cashu.MessageToCurve(message);
+        var Y = message.ToCurve();
         var B_ = Cashu.ComputeB_(Y, blindingFactor);
         var C_ = Cashu.ComputeC_(B_, a);
+        //p doesn;t have to be blinding factor. in fact it should be random nonce 
+        
         var proof = Cashu.ComputeProof(B_, a, blindingFactor);
         Cashu.VerifyProof(B_, C_, proof.e, proof.s, A);
         var C = Cashu.ComputeC(C_, blindingFactor, A);
@@ -375,7 +378,7 @@ public class UnitTest1
             "creqApWF0gaNhdGVub3N0cmFheKlucHJvZmlsZTFxeTI4d3VtbjhnaGo3dW45ZDNzaGp0bnl2OWtoMnVld2Q5aHN6OW1od2RlbjV0ZTB3ZmprY2N0ZTljdXJ4dmVuOWVlaHFjdHJ2NWhzenJ0aHdkZW41dGUwZGVoaHh0bnZkYWtxcWd5ZGFxeTdjdXJrNDM5eWtwdGt5c3Y3dWRoZGh1NjhzdWNtMjk1YWtxZWZkZWhrZjBkNDk1Y3d1bmw1YWeBgmFuYjE3YWloYjdhOTAxNzZhYQphdWNzYXRhbYF4Imh0dHBzOi8vbm9mZWVzLnRlc3RudXQuY2FzaHUuc3BhY2U=";
         var pr = PaymentRequest.Parse(creqA);
         Assert.Equal("https://nofees.testnut.cashu.space", Assert.Single( pr.Mints));
-        Assert.Equal(10, pr.Amount);
+        Assert.Equal((ulong)10, pr.Amount);
         Assert.Equal("b7a90176", pr.PaymentId);
         Assert.Equal("sat", pr.Unit);
         var t = Assert.Single(pr.Transports);

--- a/DotNut/Api/CashuHttpClient.cs
+++ b/DotNut/Api/CashuHttpClient.cs
@@ -16,28 +16,24 @@ public class CashuHttpClient : ICashuApi
     }
 
     public async Task<GetKeysResponse> GetKeys(CancellationToken cancellationToken = default)
-
     {
         var response = await _httpClient.GetAsync("v1/keys", cancellationToken);
         return await HandleResponse<GetKeysResponse>(response, cancellationToken);
     }
 
     public async Task<GetKeysetsResponse> GetKeysets(CancellationToken cancellationToken = default)
-
     {
         var response = await _httpClient.GetAsync("v1/keysets", cancellationToken);
         return await HandleResponse<GetKeysetsResponse>(response, cancellationToken);
     }
 
     public async Task<GetKeysResponse> GetKeys(KeysetId keysetId, CancellationToken cancellationToken = default)
-
     {
         var response = await _httpClient.GetAsync($"v1/keys/{keysetId}", cancellationToken);
         return await HandleResponse<GetKeysResponse>(response, cancellationToken);
     }
 
     public async Task<PostSwapResponse> Swap(PostSwapRequest request, CancellationToken cancellationToken = default)
-
     {
         var response = await _httpClient.PostAsync($"v1/swap",
             new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json"), cancellationToken);
@@ -104,6 +100,12 @@ public class CashuHttpClient : ICashuApi
         var response = await _httpClient.PostAsync($"v1/restore",
             new StringContent(JsonSerializer.Serialize(request), Encoding.UTF8, "application/json"), cancellationToken);
         return await HandleResponse<PostRestoreResponse>(response, cancellationToken);
+    }
+
+    public async Task<GetInfoResponse> GetInfo(CancellationToken cancellationToken = default)
+    {
+        var response = await _httpClient.GetAsync("v1/info", cancellationToken);
+        return await HandleResponse<GetInfoResponse>(response, cancellationToken);
     }
 
     protected async Task<T> HandleResponse<T>(HttpResponseMessage response, CancellationToken cancellationToken)

--- a/DotNut/Api/ICashuApi.cs
+++ b/DotNut/Api/ICashuApi.cs
@@ -24,4 +24,5 @@ public interface ICashuApi
     Task<TResponse> Mint<TRequest,TResponse>(string method, TRequest request,  CancellationToken cancellationToken = default);
     Task<PostCheckStateResponse> CheckState(PostCheckStateRequest request,  CancellationToken cancellationToken = default);
     Task<PostRestoreResponse> Restore(PostRestoreRequest request,  CancellationToken cancellationToken = default);
+    Task<GetInfoResponse> GetInfo(CancellationToken cancellationToken = default);
 }

--- a/DotNut/ApiModels/GetKeysetsResponse.cs
+++ b/DotNut/ApiModels/GetKeysetsResponse.cs
@@ -12,6 +12,6 @@ public class GetKeysetsResponse
         [JsonPropertyName("unit")] public string Unit { get; set; }
         [JsonPropertyName("active")] public bool Active { get; set; }
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
-        [JsonPropertyName("input_fee_ppk")] public int? InputFee { get; set; }
+        [JsonPropertyName("input_fee_ppk")] public ulong? InputFee { get; set; }
     }
 }

--- a/DotNut/ApiModels/Melt/PostMeltQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Melt/PostMeltQuoteBolt11Response.cs
@@ -8,7 +8,7 @@ public class PostMeltQuoteBolt11Response
     public string Quote { get; set; }
     
     [JsonPropertyName("amount")] 
-    public int Amount { get; set; }
+    public ulong Amount { get; set; }
     
     [JsonPropertyName("fee_reserve")] 
     public int FeeReserve { get; set; }

--- a/DotNut/ApiModels/Mint/PostMintQuoteBolt11Request.cs
+++ b/DotNut/ApiModels/Mint/PostMintQuoteBolt11Request.cs
@@ -7,7 +7,7 @@ public class PostMintQuoteBolt11Request
 {
   
     [JsonPropertyName("amount")] 
-    public int Amount {get; set;}
+    public ulong Amount {get; set;}
     
     [JsonPropertyName("unit")] 
     public string Unit {get; set;}

--- a/DotNut/ApiModels/Mint/PostMintQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Mint/PostMintQuoteBolt11Response.cs
@@ -19,7 +19,7 @@ public class PostMintQuoteBolt11Response
     // 'amount' and 'unit' were recently added to the spec in PostMintQuoteBolt11Response, so they are optional for now
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("amount")]
-    public int? Amount { get; set; }
+    public ulong? Amount { get; set; }
     
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("unit")]

--- a/DotNut/BlindSignature.cs
+++ b/DotNut/BlindSignature.cs
@@ -5,7 +5,7 @@ namespace DotNut;
 
 public class BlindSignature
 {
-    [JsonPropertyName("amount")] public int Amount { get; set; }
+    [JsonPropertyName("amount")] public ulong Amount { get; set; }
 
     [JsonConverter(typeof(KeysetIdJsonConverter))]
     [JsonPropertyName("id")]

--- a/DotNut/BlindedMessage.cs
+++ b/DotNut/BlindedMessage.cs
@@ -4,7 +4,7 @@ namespace DotNut;
 
 public class BlindedMessage
 {
-    [JsonPropertyName("amount")] public int Amount { get; set; }
+    [JsonPropertyName("amount")] public ulong Amount { get; set; }
     [JsonPropertyName("id")] public KeysetId Id { get; set; }
     [JsonPropertyName("B_")] public PubKey B_ { get; set; }
     [JsonPropertyName("witness")][JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)] public string? Witness { get; set; }

--- a/DotNut/Encoding/CashuTokenHelper.cs
+++ b/DotNut/Encoding/CashuTokenHelper.cs
@@ -10,10 +10,10 @@ public static class CashuTokenHelper
         Encoders.Add("B", new CashuTokenV4Encoder());
     }
 
-    public const string CashuUriScheme = "cashu";
+    public const string CashuUriScheme = "cashu:";
     public const string CashuPrefix = "cashu";
 
-    public static string Encode(this CashuToken token, string version = "B", bool makeUri = true)
+    public static string Encode(this CashuToken token, string version = "B", bool makeUri = false)
     {
         if (!Encoders.TryGetValue(version, out var encoder))
         {
@@ -25,14 +25,17 @@ public static class CashuTokenHelper
         {
             token2.Mint = token2.Mint.TrimEnd('/');
         }
-        var result = encoder.Encode(token);
+        
+        var encoded = encoder.Encode(token);
+
+        var result = $"{CashuPrefix}{version}{encoded}";
 
         if (makeUri)
         {
             return CashuUriScheme + result;
         }
 
-        return $"{CashuPrefix}{version}{result}";
+        return result;
     }
 
     public static CashuToken Decode(string token, out string? version)
@@ -40,7 +43,7 @@ public static class CashuTokenHelper
         version = null;
         if (Uri.IsWellFormedUriString(token, UriKind.Absolute))
         {
-            token = token.Replace(CashuUriScheme + ":", "");
+            token = token.Replace(CashuUriScheme, "");
         }
 
         if (!token.StartsWith(CashuPrefix))

--- a/DotNut/Encoding/CashuTokenV4Encoder.cs
+++ b/DotNut/Encoding/CashuTokenV4Encoder.cs
@@ -86,7 +86,7 @@ public class CashuTokenV4Encoder : ICashuTokenEncoder, ICBORToFromConverter<Cash
 
                         return proofSet["p"].Values.Select(proof => new Proof()
                         {
-                            Amount = proof["a"].AsInt32(),
+                            Amount = proof["a"].ToObject<ulong>(),
                             Secret = JsonSerializer.Deserialize<ISecret>(proof["s"].ToJSONString())!,
                             C = ECPubKey.Create(proof["c"].GetByteString()),
                             Witness = proof.GetOrDefault("w", null)?.AsString(),

--- a/DotNut/FeeHelper.cs
+++ b/DotNut/FeeHelper.cs
@@ -5,9 +5,9 @@ namespace DotNut;
 public static class FeeHelper
 {
 
-    public static int ComputeFee(this IEnumerable<Proof> proofsToSpend, Dictionary<KeysetId, int> keysetFees)
+    public static ulong ComputeFee(this IEnumerable<Proof> proofsToSpend, Dictionary<KeysetId, ulong> keysetFees)
     {
-        var sum = 0;
+        ulong sum = 0;
         foreach (var proof in proofsToSpend)
         {
             if (keysetFees.TryGetValue(proof.Id, out var fee))

--- a/DotNut/MeltMethodSetting.cs
+++ b/DotNut/MeltMethodSetting.cs
@@ -6,6 +6,6 @@ public class MeltMethodSetting
 {
     [JsonPropertyName("method")] public string Method { get; set; }
     [JsonPropertyName("unit")] public string Unit { get; set; }
-    [JsonPropertyName("min_amount")] public int? Min { get; set; }
-    [JsonPropertyName("max_amount")] public int? Max { get; set; }
+    [JsonPropertyName("min_amount")] public ulong? Min { get; set; }
+    [JsonPropertyName("max_amount")] public ulong? Max { get; set; }
 }

--- a/DotNut/MintMethodSetting.cs
+++ b/DotNut/MintMethodSetting.cs
@@ -6,8 +6,8 @@ public class MintMethodSetting
 {
     [JsonPropertyName("method")] public string Method { get; set; }
     [JsonPropertyName("unit")] public string Unit { get; set; }
-    [JsonPropertyName("min_amount")] public int? Min { get; set; }
-    [JsonPropertyName("max_amount")] public int? Max { get; set; }
+    [JsonPropertyName("min_amount")] public ulong? Min { get; set; }
+    [JsonPropertyName("max_amount")] public ulong? Max { get; set; }
     [JsonPropertyName("description")] public bool? Description { get; set; }
 }
 

--- a/DotNut/PaymentRequest.cs
+++ b/DotNut/PaymentRequest.cs
@@ -5,7 +5,7 @@ namespace DotNut;
 public class PaymentRequest
 {
     public string? PaymentId { get; set; }
-    public int? Amount { get; set; }
+    public ulong? Amount { get; set; }
     public string? Unit { get; set; }
     public bool? OneTimeUse { get; set; }
     public string[]? Mints { get; set; }

--- a/DotNut/PaymentRequestEncoder.cs
+++ b/DotNut/PaymentRequestEncoder.cs
@@ -60,7 +60,7 @@ public class PaymentRequestEncoder : ICBORToFromConverter<PaymentRequest>
                     paymentRequest.PaymentId = value.AsString();
                     break;
                 case "a":
-                    paymentRequest.Amount = value.AsInt32();
+                    paymentRequest.Amount = value.ToObject<ulong>();
                     break;
                 case "u":
                     paymentRequest.Unit = value.AsString();

--- a/DotNut/Proof.cs
+++ b/DotNut/Proof.cs
@@ -6,7 +6,7 @@ namespace DotNut;
 
 public class Proof
 {
-    [JsonPropertyName("amount")] public int Amount { get; set; }
+    [JsonPropertyName("amount")] public ulong Amount { get; set; }
 
     [JsonConverter(typeof(KeysetIdJsonConverter))]
     [JsonPropertyName("id")]


### PR DESCRIPTION
Summary:
Updated amount types and improved client functionality.

Changes:
Replaced all amount representations with ulong to match the Cashu spec (max amount per keyset is a 64-bit unsigned integer, or optionally 128-bit signed).
Added GetInfo method to CashuHttpClient.
Small fix in the token serialization.