### PR TITLE
Fix nullable Expiry field in Quote responses

### DIFF
--- a/DotNut.Tests/UnitTest1.cs
+++ b/DotNut.Tests/UnitTest1.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using DotNut.ApiModels;
 using DotNut.NUT13;
 using NBip32Fast;
 using NBitcoin;
@@ -458,5 +459,141 @@ public class UnitTest1
             Convert.ToHexString(mnemonic.DeriveBlindingFactor(keysetId, 3)).ToLowerInvariant());
         Assert.Equal("5f09bfbfe27c439a597719321e061e2e40aad4a36768bb2bcc3de547c9644bf9",
             Convert.ToHexString(mnemonic.DeriveBlindingFactor(keysetId, 4)).ToLowerInvariant());
+    }
+
+    [Fact]
+    public void NullExpiryTests_PostMintQuoteBolt11Response()
+    {
+        // Test JSON with null expiry field
+        var jsonWithNullExpiry = """
+            {
+                "quote": "test-quote-id",
+                "request": "test-request",
+                "state": "PAID",
+                "expiry": null,
+                "amount": 1000,
+                "unit": "sat"
+            }
+            """;
+
+        var response = JsonSerializer.Deserialize<PostMintQuoteBolt11Response>(jsonWithNullExpiry);
+        
+        Assert.NotNull(response);
+        Assert.Equal("test-quote-id", response.Quote);
+        Assert.Equal("test-request", response.Request);
+        Assert.Equal("PAID", response.State);
+        Assert.Null(response.Expiry);
+        Assert.Equal((ulong)1000, response.Amount);
+        Assert.Equal("sat", response.Unit);
+
+        // Test JSON without expiry field (should also be null)
+        var jsonWithoutExpiry = """
+            {
+                "quote": "test-quote-id-2",
+                "request": "test-request-2",
+                "state": "UNPAID",
+                "amount": 500,
+                "unit": "sat"
+            }
+            """;
+
+        var response2 = JsonSerializer.Deserialize<PostMintQuoteBolt11Response>(jsonWithoutExpiry);
+        
+        Assert.NotNull(response2);
+        Assert.Equal("test-quote-id-2", response2.Quote);
+        Assert.Equal("test-request-2", response2.Request);
+        Assert.Equal("UNPAID", response2.State);
+        Assert.Null(response2.Expiry);
+        Assert.Equal((ulong)500, response2.Amount);
+        Assert.Equal("sat", response2.Unit);
+
+        // Test JSON with valid expiry value (should still work)
+        var jsonWithExpiry = """
+            {
+                "quote": "test-quote-id-3",
+                "request": "test-request-3",
+                "state": "ISSUED",
+                "expiry": 1640995200,
+                "amount": 2000,
+                "unit": "sat"
+            }
+            """;
+
+        var response3 = JsonSerializer.Deserialize<PostMintQuoteBolt11Response>(jsonWithExpiry);
+        
+        Assert.NotNull(response3);
+        Assert.Equal("test-quote-id-3", response3.Quote);
+        Assert.Equal("test-request-3", response3.Request);
+        Assert.Equal("ISSUED", response3.State);
+        Assert.Equal(1640995200, response3.Expiry);
+        Assert.Equal((ulong)2000, response3.Amount);
+        Assert.Equal("sat", response3.Unit);
+    }
+
+    [Fact]
+    public void NullExpiryTests_PostMeltQuoteBolt11Response()
+    {
+        // Test JSON with null expiry field
+        var jsonWithNullExpiry = """
+            {
+                "quote": "melt-quote-id",
+                "amount": 1000,
+                "fee_reserve": 50,
+                "state": "PAID",
+                "expiry": null,
+                "payment_preimage": "test-preimage"
+            }
+            """;
+
+        var response = JsonSerializer.Deserialize<PostMeltQuoteBolt11Response>(jsonWithNullExpiry);
+        
+        Assert.NotNull(response);
+        Assert.Equal("melt-quote-id", response.Quote);
+        Assert.Equal((ulong)1000, response.Amount);
+        Assert.Equal(50, response.FeeReserve);
+        Assert.Equal("PAID", response.State);
+        Assert.Null(response.Expiry);
+        Assert.Equal("test-preimage", response.PaymentPreimage);
+
+        // Test JSON without expiry field (should also be null)
+        var jsonWithoutExpiry = """
+            {
+                "quote": "melt-quote-id-2",
+                "amount": 500,
+                "fee_reserve": 25,
+                "state": "UNPAID"
+            }
+            """;
+
+        var response2 = JsonSerializer.Deserialize<PostMeltQuoteBolt11Response>(jsonWithoutExpiry);
+        
+        Assert.NotNull(response2);
+        Assert.Equal("melt-quote-id-2", response2.Quote);
+        Assert.Equal((ulong)500, response2.Amount);
+        Assert.Equal(25, response2.FeeReserve);
+        Assert.Equal("UNPAID", response2.State);
+        Assert.Null(response2.Expiry);
+        Assert.Null(response2.PaymentPreimage);
+
+        // Test JSON with valid expiry value (should still work)
+        var jsonWithExpiry = """
+            {
+                "quote": "melt-quote-id-3",
+                "amount": 2000,
+                "fee_reserve": 100,
+                "state": "PENDING",
+                "expiry": 1640995200
+            }
+            """;
+
+        var response3 = JsonSerializer.Deserialize<PostMeltQuoteBolt11Response>(jsonWithExpiry);
+        
+        Assert.NotNull(response3);
+        Assert.Equal("melt-quote-id-3", response3.Quote);
+        Assert.Equal((ulong)2000, response3.Amount);
+        Assert.Equal(100, response3.FeeReserve);
+        Assert.Equal("PENDING", response3.State);
+        Assert.Equal(1640995200, response3.Expiry);
+        Assert.Null(response3.PaymentPreimage);
     }
 }

--- a/DotNut/ApiModels/Melt/PostMeltQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Melt/PostMeltQuoteBolt11Response.cs
@@ -16,8 +16,9 @@ public class PostMeltQuoteBolt11Response
     [JsonPropertyName("state")]
     public string State {get; set;}
     
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("expiry")]
-    public int Expiry {get; set;}
+    public int? Expiry {get; set;}
     
     [JsonPropertyName("payment_preimage")]
     public string? PaymentPreimage {get; set;}

--- a/DotNut/ApiModels/Mint/PostMintQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Mint/PostMintQuoteBolt11Response.cs
@@ -13,8 +13,9 @@ public class PostMintQuoteBolt11Response
     [JsonPropertyName("state")] 
     public string State { get; set; }
     
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("expiry")] 
-    public int Expiry { get; set; }
+    public int? Expiry { get; set; }
     
     // 'amount' and 'unit' were recently added to the spec in PostMintQuoteBolt11Response, so they are optional for now
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]


### PR DESCRIPTION
## Summary
  Fixes JSON deserialization errors when the `expiry` field in Quote responses is `null`. This issue commonly occurs with test
  mints like `https://testnut.cashu.space` that return `null` expiry values for paid or expired quotes.

  ## Changes
  - Changed `Expiry` field from `int` to `int?` in `PostMintQuoteBolt11Response`
  - Changed `Expiry` field from `int` to `int?` in `PostMeltQuoteBolt11Response`
  - Added `JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)` to both fields
  - Added comprehensive unit tests covering:
    - JSON with explicit `"expiry": null`
    - JSON without `expiry` field
    - JSON with valid expiry values (backward compatibility)

  ## Test plan
  - [x] All existing tests pass (26/26)
  - [x] New tests for null expiry scenarios pass (2/2)
  - [x] Build succeeds without errors
  - [x] Deserialization works with test mint responses

  ## Problem solved
  Before this fix, attempting to deserialize Quote responses with `null` expiry values would throw JSON deserialization
  exceptions. This is particularly problematic when working with test mints that set expiry to `null` once quotes are processed.

  After this fix, the library gracefully handles `null` expiry values while maintaining full backward compatibility with mints
  that provide valid expiry timestamps.