### PR TITLE
Add separator to keyset derivation. Add final_expiry to GetKeysResponse

### DIFF
--- a/DotNut/ApiModels/GetKeysResponse.cs
+++ b/DotNut/ApiModels/GetKeysResponse.cs
@@ -10,6 +10,8 @@ public class GetKeysResponse
     {
         [JsonPropertyName("id")] public KeysetId Id { get; set; }
         [JsonPropertyName("unit")] public string Unit { get; set; }
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+        [JsonPropertyName("final_expiry")] public ulong? FinalExpiry { get; set; }
         [JsonPropertyName("keys")] public Keyset Keys { get; set; }
     }
 }

--- a/DotNut/Keyset.cs
+++ b/DotNut/Keyset.cs
@@ -44,11 +44,11 @@ public class Keyset : Dictionary<ulong, PubKey>
                 { 
                     throw new ArgumentNullException( nameof(unit), $"Unit parameter is required with version: {version}");
                 }
-                sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"unit:{unit.Trim().ToLowerInvariant()}")).ToArray();
+                sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"|unit:{unit.Trim().ToLowerInvariant()}")).ToArray();
                 
                 if (!string.IsNullOrWhiteSpace(finalExpiration))
                 {
-                    sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"final_expiry:{finalExpiration.Trim()}"))
+                    sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"|final_expiry:{finalExpiration.Trim()}"))
                         .ToArray();
                 }
 


### PR DESCRIPTION
https://github.com/cashubtc/nuts/pull/182#issuecomment-3315077813

https://github.com/cashubtc/nuts/pull/182#pullrequestreview-3259213782

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional “final_expiry” field to keyset items in key retrieval responses.
  * Updated KeysetId generation for version 0x01 to include clearer field delimiters, which will change resulting IDs for affected keysets.

* **Chores**
  * Improved serialization behavior to omit the new field when not set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->