### PR TITLE
remove separators

### DIFF
--- a/DotNut/Keyset.cs
+++ b/DotNut/Keyset.cs
@@ -44,11 +44,11 @@ public class Keyset : Dictionary<ulong, PubKey>
                 { 
                     throw new ArgumentNullException( nameof(unit), $"Unit parameter is required with version: {version}");
                 }
-                sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"|unit:{unit.Trim().ToLowerInvariant()}")).ToArray();
+                sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"unit:{unit.Trim().ToLowerInvariant()}")).ToArray();
                 
                 if (!string.IsNullOrWhiteSpace(finalExpiration))
                 {
-                    sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"|final_expiry:{finalExpiration.Trim()}"))
+                    sortedBytes = sortedBytes.Concat(Encoding.UTF8.GetBytes($"final_expiry:{finalExpiration.Trim()}"))
                         .ToArray();
                 }
 


### PR DESCRIPTION
no separators again

https://github.com/cashubtc/nuts/pull/182/commits/1efb5a4b50a1f97475212523e40706870f88eec0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Improved consistency in keyset ID generation for version 0x01.

- Bug Fixes
  - Corrected formatting used when computing keyset IDs for version 0x01, preventing mismatches caused by inconsistent delimiters.

- Documentation
  - Clarified expected keyset ID behavior for version 0x01.

- Chores
  - Updated internal hashing input construction to align with standardized formatting rules for version 0x01, which may alter newly generated IDs without affecting existing stored values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->