### PR TITLE
fix padding

### DIFF
--- a/DotNut/NUT13/BIP32.cs
+++ b/DotNut/NUT13/BIP32.cs
@@ -55,6 +55,12 @@ public class BIP32 : IHdKeyAlgo
             }
 
             var keyBytes = res.ToByteArray(true, true);
+            if (keyBytes.Length < 32)
+            {
+                var paddedKey = new byte[32];
+                keyBytes.CopyTo(paddedKey, 32 - keyBytes.Length);
+                keyBytes = paddedKey;
+            }
             return new HdKey(keyBytes, cc);
         }
     }


### PR DESCRIPTION
Without that, deriving anything for keysetId 001b6c716bf42c7e with counter = 86 threw an exception. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensures all derived keys are consistently 32 bytes, improving reliability of key generation.
  * Prevents rare failures or inconsistencies when leading zeros would produce shorter key lengths.
  * Enhances compatibility with tools and wallets expecting fixed-size keys.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->