### PR TITLE
NUT-20/29: length-prefixed quote signature message

### DIFF
--- a/DotNut.Tests/Nut20Tests.cs
+++ b/DotNut.Tests/Nut20Tests.cs
@@ -1,33 +1,124 @@
 using System.Text.Json;
 using DotNut.ApiModels;
-using NBitcoin.Secp256k1;
 using SHA256 = System.Security.Cryptography.SHA256;
+
 namespace DotNut.Tests;
 
 public class Nut20Tests
 {
+    // Test vector from tests/20-test.md. The quote pubkey belongs to secret key 0x01.
+    private const string SignedMintQuote = """
+        {
+          "quote": "0192d3c0-7e8a-7c3d-8e9f-1a2b3c4d5e6f",
+          "outputs": [
+            {
+              "amount": 1,
+              "id": "009a1f293253e41e",
+              "B_": "036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2"
+            },
+            {
+              "amount": 1,
+              "id": "009a1f293253e41e",
+              "B_": "021f8a566c205633d029094747d2e18f44e05993dda7a5f88f496078205f656e59"
+            }
+          ],
+          "signature": "4881093a332ff7c79f3e598ce5b249d64978b47165a0b19c18adf0ced0246228e61e702f0abaf1bf27b92be4336bdbabacfbe4c914076386b3c66fdcd0b3480e"
+        }
+        """;
+
+    private const string QuotePubkey =
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    [Fact]
+    public void MessageToSignMatchesTestVector()
+    {
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        var msg = MintQuoteSigner.GetMessageToSign(parsed.Quote, parsed.Outputs);
+
+        // "Cashu_MintQuoteSig_v1" || len32(quote) || quote || (len32(amount) || amount
+        // || len32(B_) || B_) per output.
+        Assert.Equal(
+            "43617368755f4d696e7451756f74655369675f7631"
+                + "00000024"
+                + "30313932643363302d376538612d376333642d386539662d316132623363346435653666"
+                + "00000001"
+                + "01"
+                + "00000021"
+                + "036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2"
+                + "00000001"
+                + "01"
+                + "00000021"
+                + "021f8a566c205633d029094747d2e18f44e05993dda7a5f88f496078205f656e59",
+            Convert.ToHexString(msg).ToLowerInvariant()
+        );
+
+        Assert.Equal(
+            "c164fd384879f74ab6ea2e7cf13d90ed42e6df9d5de607eeb5c9cc7d36fb1c21",
+            Convert.ToHexString(SHA256.HashData(msg)).ToLowerInvariant()
+        );
+    }
+
     [Fact]
     public void ValidSignatureOnMintQuote()
     {
-        var validSignedMintQuote = "{\n  \"quote\": \"9d745270-1405-46de-b5c5-e2762b4f5e00\",\n  \"outputs\": [\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"0342e5bcc77f5b2a3c2afb40bb591a1e27da83cddc968abdc0ec4904201a201834\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"032fd3c4dc49a2844a89998d5e9d5b0f0b00dde9310063acb8a92e2fdafa4126d4\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"033b6fde50b6a0dfe61ad148fff167ad9cf8308ded5f6f6b2fe000a036c464c311\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"02be5a55f03e5c0aaea77595d574bce92c6d57a2a0fb2b5955c0b87e4520e06b53\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"02209fc2873f28521cbdde7f7b3bb1521002463f5979686fd156f23fe6a8aa2b79\"\n    }\n  ],\n  \"signature\": \"d4b386f21f7aa7172f0994ee6e4dd966539484247ea71c99b81b8e09b1bb2acbc0026a43c221fd773471dc30d6a32b04692e6837ddaccf0830a63128308e4ee0\"\n}";
-        var signedParsed = JsonSerializer.Deserialize<PostMintRequest>(validSignedMintQuote);
-        var pubkey = new PubKey( "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac");
-        byte[] expectedMsg = [57, 100, 55, 52, 53, 50, 55, 48, 45, 49, 52, 48, 53, 45, 52, 54, 100, 101, 45, 98, 53, 99, 53, 45, 101, 50, 55, 54, 50, 98, 52, 102, 53, 101, 48, 48, 48, 51, 52, 50, 101, 53, 98, 99, 99, 55, 55, 102, 53, 98, 50, 97, 51, 99, 50, 97, 102, 98, 52, 48, 98, 98, 53, 57, 49, 97, 49, 101, 50, 55, 100, 97, 56, 51, 99, 100, 100, 99, 57, 54, 56, 97, 98, 100, 99, 48, 101, 99, 52, 57, 48, 52, 50, 48, 49, 97, 50, 48, 49, 56, 51, 52, 48, 51, 50, 102, 100, 51, 99, 52, 100, 99, 52, 57, 97, 50, 56, 52, 52, 97, 56, 57, 57, 57, 56, 100, 53, 101, 57, 100, 53, 98, 48, 102, 48, 98, 48, 48, 100, 100, 101, 57, 51, 49, 48, 48, 54, 51, 97, 99, 98, 56, 97, 57, 50, 101, 50, 102, 100, 97, 102, 97, 52, 49, 50, 54, 100, 52, 48, 51, 51, 98, 54, 102, 100, 101, 53, 48, 98, 54, 97, 48, 100, 102, 101, 54, 49, 97, 100, 49, 52, 56, 102, 102, 102, 49, 54, 55, 97, 100, 57, 99, 102, 56, 51, 48, 56, 100, 101, 100, 53, 102, 54, 102, 54, 98, 50, 102, 101, 48, 48, 48, 97, 48, 51, 54, 99, 52, 54, 52, 99, 51, 49, 49, 48, 50, 98, 101, 53, 97, 53, 53, 102, 48, 51, 101, 53, 99, 48, 97, 97, 101, 97, 55, 55, 53, 57, 53, 100, 53, 55, 52, 98, 99, 101, 57, 50, 99, 54, 100, 53, 55, 97, 50, 97, 48, 102, 98, 50, 98, 53, 57, 53, 53, 99, 48, 98, 56, 55, 101, 52, 53, 50, 48, 101, 48, 54, 98, 53, 51, 48, 50, 50, 48, 57, 102, 99, 50, 56, 55, 51, 102, 50, 56, 53, 50, 49, 99, 98, 100, 100, 101, 55, 102, 55, 98, 51, 98, 98, 49, 53, 50, 49, 48, 48, 50, 52, 54, 51, 102, 53, 57, 55, 57, 54, 56, 54, 102, 100, 49, 53, 54, 102, 50, 51, 102, 101, 54, 97, 56, 97, 97, 50, 98, 55, 57];
-        Assert.NotNull(signedParsed);
-        
-        var msg = MintQuoteSigner.GetMessageToSign(signedParsed.Quote, signedParsed.Outputs);
-        Assert.True(msg.SequenceEqual(expectedMsg));
-        
-        Assert.True(signedParsed.VerifySignature(pubkey));
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        Assert.True(parsed.VerifySignature(new PubKey(QuotePubkey)));
     }
 
     [Fact]
     public void InvalidSignatureOnMintQuote()
     {
-        var invalidSignedMintQuote = "{\n  \"quote\": \"9d745270-1405-46de-b5c5-e2762b4f5e00\",\n  \"outputs\": [\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"0342e5bcc77f5b2a3c2afb40bb591a1e27da83cddc968abdc0ec4904201a201834\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"032fd3c4dc49a2844a89998d5e9d5b0f0b00dde9310063acb8a92e2fdafa4126d4\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"033b6fde50b6a0dfe61ad148fff167ad9cf8308ded5f6f6b2fe000a036c464c311\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"02be5a55f03e5c0aaea77595d574bce92c6d57a2a0fb2b5955c0b87e4520e06b53\"\n    },\n    {\n      \"amount\": 1,\n      \"id\": \"00456a94ab4e1c46\",\n      \"B_\": \"02209fc2873f28521cbdde7f7b3bb1521002463f5979686fd156f23fe6a8aa2b79\"\n    }\n  ],\n  \"signature\": \"cb2b8e7ea69362dfe2a07093f2bbc319226db33db2ef686c940b5ec976bcbfc78df0cd35b3e998adf437b09ee2c950bd66dfe9eb64abd706e43ebc7c669c36c3\"\n}";
-        var signedParsed = JsonSerializer.Deserialize<PostMintRequest>(invalidSignedMintQuote);
-        var pubkey = new PubKey("03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac");
-        Assert.NotNull(signedParsed);
-        Assert.False(signedParsed.VerifySignature(pubkey));
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        // Same request, signature off by its last byte.
+        parsed.Signature = parsed.Signature![..^2] + "0f";
+
+        Assert.False(parsed.VerifySignature(new PubKey(QuotePubkey)));
+    }
+
+    [Fact]
+    public void SignatureCoversTheOutputs()
+    {
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        // Swapping two outputs keeps the same set but changes the order they are committed in.
+        (parsed.Outputs[0], parsed.Outputs[1]) = (parsed.Outputs[1], parsed.Outputs[0]);
+
+        Assert.False(parsed.VerifySignature(new PubKey(QuotePubkey)));
+    }
+
+    [Fact]
+    public void SignAndVerifyRoundTrip()
+    {
+        var privkey = new PrivKey(
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        );
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        parsed.Signature = privkey.SignMintQuote(parsed.Quote, parsed.Outputs.ToList());
+
+        Assert.True(parsed.VerifySignature(new PubKey(QuotePubkey)));
+    }
+
+    [Theory]
+    // Canonical minimal big-endian: zero is empty, no leading zero bytes.
+    [InlineData(0UL, "")]
+    [InlineData(1UL, "01")]
+    [InlineData(255UL, "ff")]
+    [InlineData(256UL, "0100")]
+    [InlineData(ulong.MaxValue, "ffffffffffffffff")]
+    public void AmountsUseMinimalBigEndian(ulong amount, string expected)
+    {
+        Assert.Equal(
+            expected,
+            Convert.ToHexString(MintQuoteSigner.ToMinimalBigEndian(amount)).ToLowerInvariant()
+        );
     }
 }

--- a/DotNut.Tests/Nut20Tests.cs
+++ b/DotNut.Tests/Nut20Tests.cs
@@ -107,6 +107,40 @@ public class Nut20Tests
         Assert.True(parsed.VerifySignature(new PubKey(QuotePubkey)));
     }
 
+    [Fact]
+    public void LegacySignatureIsAcceptedUnlessRefused()
+    {
+        var privkey = new PrivKey(
+            "0000000000000000000000000000000000000000000000000000000000000001"
+        );
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        parsed.Signature = privkey.SignMintQuoteLegacy(parsed.Quote, parsed.Outputs.ToList());
+
+        // Mints that understand the current message still accept the superseded one, the way
+        // cdk and nutshell do, but a caller can insist on the current format.
+        Assert.True(parsed.VerifySignature(new PubKey(QuotePubkey)));
+        Assert.False(parsed.VerifySignature(new PubKey(QuotePubkey), allowLegacy: false));
+    }
+
+    [Fact]
+    public void LegacyMessageIsTheSupersededFormat()
+    {
+        var parsed = JsonSerializer.Deserialize<PostMintRequest>(SignedMintQuote);
+        Assert.NotNull(parsed);
+
+        var msg = MintQuoteSigner.GetLegacyMessageToSign(parsed.Quote, parsed.Outputs);
+
+        // Quote id and the hex of every output, concatenated as UTF-8. No domain tag, no lengths.
+        Assert.Equal(
+            "0192d3c0-7e8a-7c3d-8e9f-1a2b3c4d5e6f"
+                + "036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2"
+                + "021f8a566c205633d029094747d2e18f44e05993dda7a5f88f496078205f656e59",
+            System.Text.Encoding.UTF8.GetString(msg)
+        );
+    }
+
     [Theory]
     // Canonical minimal big-endian: zero is empty, no leading zero bytes.
     [InlineData(0UL, "")]

--- a/DotNut.Tests/Unit/Nut29Tests.cs
+++ b/DotNut.Tests/Unit/Nut29Tests.cs
@@ -1,0 +1,138 @@
+using System.Text.Json;
+using DotNut.ApiModels;
+using NBitcoin.Secp256k1;
+using SHA256 = System.Security.Cryptography.SHA256;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut29Tests
+{
+    // Test vector from tests/29-tests.md, "Batch mint with valid signature". sk = 1.
+    private const string BatchRequest = """
+        {
+          "quotes": ["019e6d5a-2347-7000-8c81-a1e0dbf3299f"],
+          "outputs": [
+            {
+              "amount": 1,
+              "id": "010000000000000000000000000000000000000000000000000000000000000000",
+              "B_": "036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2"
+            },
+            {
+              "amount": 1,
+              "id": "010000000000000000000000000000000000000000000000000000000000000000",
+              "B_": "021f8a566c205633d029094747d2e18f44e05993dda7a5f88f496078205f656e59"
+            }
+          ]
+        }
+        """;
+
+    private const string QuoteId = "019e6d5a-2347-7000-8c81-a1e0dbf3299f";
+
+    private const string QuotePubkey =
+        "0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798";
+
+    private static readonly PrivKey QuotePrivkey = new(
+        "0000000000000000000000000000000000000000000000000000000000000001"
+    );
+
+    [Fact]
+    public void BatchMessageIsTheNut20MessageOverEveryOutput()
+    {
+        var request = JsonSerializer.Deserialize<PostBatchedMintRequest>(BatchRequest);
+        Assert.NotNull(request);
+
+        var msg = MintQuoteSigner.GetMessageToSign(QuoteId, request.Outputs);
+
+        Assert.Equal(
+            "43617368755f4d696e7451756f74655369675f7631"
+                + "00000024"
+                + "30313965366435612d323334372d373030302d386338312d613165306462663332393966"
+                + "00000001"
+                + "01"
+                + "00000021"
+                + "036d6caac248af96f6afa7f904f550253a0f3ef3f5aa2fe6838a95b216691468e2"
+                + "00000001"
+                + "01"
+                + "00000021"
+                + "021f8a566c205633d029094747d2e18f44e05993dda7a5f88f496078205f656e59",
+            Convert.ToHexString(msg).ToLowerInvariant()
+        );
+
+        Assert.Equal(
+            "dad25acc587637206d73398894d337f983a0ca644746e8673727eaa0b29fa9b4",
+            Convert.ToHexString(SHA256.HashData(msg)).ToLowerInvariant()
+        );
+    }
+
+    [Fact]
+    public void VectorSignatureVerifies()
+    {
+        var request = JsonSerializer.Deserialize<PostBatchedMintRequest>(BatchRequest);
+        Assert.NotNull(request);
+
+        const string vectorSignature =
+            "0c39431338a0202568b9a1d4215c99f179cbb8ee5472ac5ae7133fbb8f99cafb"
+            + "b9e425ad33c60224c96b8f9f984f004379a18e9558468d129b6b03f0da6de162";
+
+        Assert.True(VerifyBatchSignature(request, QuoteId, vectorSignature, QuotePubkey));
+    }
+
+    [Fact]
+    public void SignsOnlyTheLockedQuotes()
+    {
+        var request = JsonSerializer.Deserialize<PostBatchedMintRequest>(BatchRequest);
+        Assert.NotNull(request);
+        request.QuoteIds = [QuoteId, "unlocked-quote"];
+
+        request.Sign(new Dictionary<string, PrivKey> { [QuoteId] = QuotePrivkey });
+
+        Assert.NotNull(request.Signatures);
+        // One entry per quote, null where the quote carries no pubkey.
+        Assert.Equal(2, request.Signatures.Length);
+        Assert.Null(request.Signatures[1]);
+        Assert.True(
+            VerifyBatchSignature(request, QuoteId, request.Signatures[0]!, QuotePubkey)
+        );
+    }
+
+    [Fact]
+    public void LeavesSignaturesUnsetWhenNoQuoteIsLocked()
+    {
+        var request = JsonSerializer.Deserialize<PostBatchedMintRequest>(BatchRequest);
+        Assert.NotNull(request);
+
+        request.Sign(new Dictionary<string, PrivKey>());
+
+        Assert.Null(request.Signatures);
+    }
+
+    [Fact]
+    public void SignatureCoversEveryOutputInTheBatch()
+    {
+        var request = JsonSerializer.Deserialize<PostBatchedMintRequest>(BatchRequest);
+        Assert.NotNull(request);
+
+        request.Sign(new Dictionary<string, PrivKey> { [QuoteId] = QuotePrivkey });
+        var signature = request.Signatures![0]!;
+
+        // Dropping an output from the consolidated set invalidates every quote's signature.
+        request.Outputs = [request.Outputs[0]];
+
+        Assert.False(VerifyBatchSignature(request, QuoteId, signature, QuotePubkey));
+    }
+
+    private static bool VerifyBatchSignature(
+        PostBatchedMintRequest request,
+        string quoteId,
+        string signature,
+        string pubkey
+    )
+    {
+        var hash = SHA256.HashData(MintQuoteSigner.GetMessageToSign(quoteId, request.Outputs));
+        if (!SecpSchnorrSignature.TryCreate(Convert.FromHexString(signature), out var sig))
+        {
+            return false;
+        }
+        return new PubKey(pubkey).Key.ToXOnlyPubKey().SigVerifyBIP340(sig, hash);
+    }
+}

--- a/DotNut/Abstractions/Handlers/MintHandlerBolt11.cs
+++ b/DotNut/Abstractions/Handlers/MintHandlerBolt11.cs
@@ -62,7 +62,7 @@ public class MintHandlerBolt11(
             promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt11", req, ct);
         }
         catch (CashuProtocolException e)
-            when (e.Error.Code == MintQuoteSigner.InvalidSignatureErrorCode
+            when (e.Error.Code == CashuErrorCodes.MintRequestSignatureInvalid
                 && _signingKey is not null
             )
         {

--- a/DotNut/Abstractions/Handlers/MintHandlerBolt11.cs
+++ b/DotNut/Abstractions/Handlers/MintHandlerBolt11.cs
@@ -1,3 +1,4 @@
+using DotNut.Api;
 using DotNut.ApiModels;
 
 namespace DotNut.Abstractions.Handlers;
@@ -10,6 +11,7 @@ public class MintHandlerBolt11(
 ) : IMintHandler<PostMintQuoteBolt11Response, List<Proof>>
 {
     private string? _signature;
+    private PrivKey? _signingKey;
 
     public IMintHandler<PostMintQuoteBolt11Response, List<Proof>> WithSignature(string signature)
     {
@@ -24,6 +26,7 @@ public class MintHandlerBolt11(
 
     public IMintHandler<PostMintQuoteBolt11Response, List<Proof>> SignWithPrivkey(PrivKey privkey)
     {
+        this._signingKey = privkey;
         this._signature = privkey.SignMintQuote(
             postMintQuoteBolt11Response.Quote,
             outputs.Select(o => o.BlindedMessage).ToList()
@@ -53,7 +56,25 @@ public class MintHandlerBolt11(
             Signature = _signature,
         };
 
-        var promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt11", req, ct);
+        PostMintResponse promises;
+        try
+        {
+            promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt11", req, ct);
+        }
+        catch (CashuProtocolException e)
+            when (e.Error.Code == MintQuoteSigner.InvalidSignatureErrorCode
+                && _signingKey is not null
+            )
+        {
+            // The mint predates the domain-separated NUT-20 message. Nothing was issued, so
+            // signing the same outputs again with the superseded message is safe.
+            req.Signature = _signingKey.SignMintQuoteLegacy(
+                postMintQuoteBolt11Response.Quote,
+                req.Outputs.ToList()
+            );
+            promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt11", req, ct);
+        }
+
         return Utils.ConstructProofsFromPromises(
             promises.Signatures.ToList(),
             outputs,

--- a/DotNut/Abstractions/Handlers/MintHandlerBolt12.cs
+++ b/DotNut/Abstractions/Handlers/MintHandlerBolt12.cs
@@ -1,3 +1,4 @@
+using DotNut.Api;
 using DotNut.ApiModels;
 using DotNut.ApiModels.Mint.bolt12;
 
@@ -11,6 +12,7 @@ public class MintHandlerBolt12(
 ) : IMintHandler<PostMintQuoteBolt12Response, List<Proof>>
 {
     private string? _signature;
+    private PrivKey? _signingKey;
 
     public IMintHandler<PostMintQuoteBolt12Response, List<Proof>> WithSignature(string signature)
     {
@@ -25,6 +27,7 @@ public class MintHandlerBolt12(
 
     public IMintHandler<PostMintQuoteBolt12Response, List<Proof>> SignWithPrivkey(PrivKey privkey)
     {
+        this._signingKey = privkey;
         this._signature = privkey.SignMintQuote(
             quote.Quote,
             outputs.Select(o => o.BlindedMessage).ToList()
@@ -54,7 +57,22 @@ public class MintHandlerBolt12(
             Signature = _signature,
         };
 
-        var promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt12", req, ct);
+        PostMintResponse promises;
+        try
+        {
+            promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt12", req, ct);
+        }
+        catch (CashuProtocolException e)
+            when (e.Error.Code == MintQuoteSigner.InvalidSignatureErrorCode
+                && _signingKey is not null
+            )
+        {
+            // The mint predates the domain-separated NUT-20 message. Nothing was issued, so
+            // signing the same outputs again with the superseded message is safe.
+            req.Signature = _signingKey.SignMintQuoteLegacy(quote.Quote, req.Outputs.ToList());
+            promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt12", req, ct);
+        }
+
         return Utils.ConstructProofsFromPromises(
             promises.Signatures.ToList(),
             outputs,

--- a/DotNut/Abstractions/Handlers/MintHandlerBolt12.cs
+++ b/DotNut/Abstractions/Handlers/MintHandlerBolt12.cs
@@ -63,7 +63,7 @@ public class MintHandlerBolt12(
             promises = await client.Mint<PostMintRequest, PostMintResponse>("bolt12", req, ct);
         }
         catch (CashuProtocolException e)
-            when (e.Error.Code == MintQuoteSigner.InvalidSignatureErrorCode
+            when (e.Error.Code == CashuErrorCodes.MintRequestSignatureInvalid
                 && _signingKey is not null
             )
         {

--- a/DotNut/Api/CashuErrorCodes.cs
+++ b/DotNut/Api/CashuErrorCodes.cs
@@ -1,0 +1,116 @@
+namespace DotNut.Api;
+
+/// <summary>
+/// Codes a mint returns in <see cref="CashuProtocolError.Code"/>, as listed in the spec's
+/// error_codes.md. The descriptions are the spec wording.
+/// </summary>
+public static class CashuErrorCodes
+{
+    /// <summary>Proof verification failed. NUT-03, NUT-05.</summary>
+    public const int ProofVerificationFailed = 10001;
+
+    /// <summary>Proofs already spent. NUT-03, NUT-05.</summary>
+    public const int ProofsAlreadySpent = 11001;
+
+    /// <summary>Proofs are pending. NUT-03, NUT-05.</summary>
+    public const int ProofsPending = 11002;
+
+    /// <summary>Outputs already signed. NUT-03, NUT-04, NUT-05.</summary>
+    public const int OutputsAlreadySigned = 11003;
+
+    /// <summary>Outputs are pending. NUT-03, NUT-04, NUT-05.</summary>
+    public const int OutputsPending = 11004;
+
+    /// <summary>Transaction is not balanced (inputs != outputs). NUT-02, NUT-03, NUT-05.</summary>
+    public const int TransactionNotBalanced = 11005;
+
+    /// <summary>Amount outside of limit range. NUT-04, NUT-05.</summary>
+    public const int AmountOutsideLimitRange = 11006;
+
+    /// <summary>Duplicate inputs provided. NUT-03, NUT-04, NUT-05.</summary>
+    public const int DuplicateInputs = 11007;
+
+    /// <summary>Duplicate outputs provided. NUT-03, NUT-04, NUT-05.</summary>
+    public const int DuplicateOutputs = 11008;
+
+    /// <summary>Inputs/Outputs of multiple units. NUT-03, NUT-04, NUT-05.</summary>
+    public const int MultipleUnits = 11009;
+
+    /// <summary>Inputs and outputs not of same unit. NUT-03, NUT-04, NUT-05.</summary>
+    public const int InputsAndOutputsNotSameUnit = 11010;
+
+    /// <summary>Amountless invoice is not supported. NUT-05.</summary>
+    public const int AmountlessInvoiceNotSupported = 11011;
+
+    /// <summary>Amount in request does not equal invoice. NUT-05.</summary>
+    public const int AmountDoesNotEqualInvoice = 11012;
+
+    /// <summary>Unit in request is not supported. NUT-04, NUT-05.</summary>
+    public const int UnitNotSupported = 11013;
+
+    /// <summary>Max inputs exceeded. NUT-03, NUT-05.</summary>
+    public const int MaxInputsExceeded = 11014;
+
+    /// <summary>Max outputs exceeded. NUT-03, NUT-04, NUT-05.</summary>
+    public const int MaxOutputsExceeded = 11015;
+
+    /// <summary>Duplicate quote IDs provided. NUT-29.</summary>
+    public const int DuplicateQuoteIds = 11016;
+
+    /// <summary>Max batch size exceeded. NUT-29.</summary>
+    public const int MaxBatchSizeExceeded = 11017;
+
+    /// <summary>Keyset is not known. NUT-02, NUT-04.</summary>
+    public const int KeysetNotKnown = 12001;
+
+    /// <summary>Keyset is inactive, cannot sign messages. NUT-02, NUT-03, NUT-04.</summary>
+    public const int KeysetInactive = 12002;
+
+    /// <summary>Keyset has expired. NUT-02, NUT-03, NUT-04, NUT-05.</summary>
+    public const int KeysetExpired = 12003;
+
+    /// <summary>Quote request is not paid. NUT-04.</summary>
+    public const int QuoteNotPaid = 20001;
+
+    /// <summary>Quote has already been issued. NUT-04.</summary>
+    public const int QuoteAlreadyIssued = 20002;
+
+    /// <summary>Minting is disabled. NUT-04.</summary>
+    public const int MintingDisabled = 20003;
+
+    /// <summary>Lightning payment failed. NUT-05.</summary>
+    public const int LightningPaymentFailed = 20004;
+
+    /// <summary>Quote is pending. NUT-04, NUT-05, NUT-29.</summary>
+    public const int QuotePending = 20005;
+
+    /// <summary>Invoice already paid. NUT-05.</summary>
+    public const int InvoiceAlreadyPaid = 20006;
+
+    /// <summary>Quote is expired. NUT-04, NUT-05.</summary>
+    public const int QuoteExpired = 20007;
+
+    /// <summary>Signature for mint request invalid. NUT-20.</summary>
+    public const int MintRequestSignatureInvalid = 20008;
+
+    /// <summary>Pubkey required for mint quote. NUT-20.</summary>
+    public const int PubkeyRequiredForMintQuote = 20009;
+
+    /// <summary>Endpoint requires clear auth. NUT-21.</summary>
+    public const int ClearAuthRequired = 30001;
+
+    /// <summary>Clear authentication failed. NUT-21.</summary>
+    public const int ClearAuthFailed = 30002;
+
+    /// <summary>Endpoint requires blind auth. NUT-22.</summary>
+    public const int BlindAuthRequired = 31001;
+
+    /// <summary>Blind authentication failed. NUT-22.</summary>
+    public const int BlindAuthFailed = 31002;
+
+    /// <summary>Maximum BAT mint amount exceeded. NUT-22.</summary>
+    public const int MaxBatMintAmountExceeded = 31003;
+
+    /// <summary>BAT mint rate limit exceeded. NUT-22.</summary>
+    public const int BatMintRateLimitExceeded = 31004;
+}

--- a/DotNut/NUT20/MintQuoteSigner.cs
+++ b/DotNut/NUT20/MintQuoteSigner.cs
@@ -1,3 +1,5 @@
+using System.Buffers;
+using System.Buffers.Binary;
 using System.Text;
 using DotNut.ApiModels;
 using NBitcoin.Secp256k1;
@@ -7,6 +9,11 @@ namespace DotNut;
 
 public static class MintQuoteSigner
 {
+    /// <summary>
+    /// Domain separation tag, written as raw bytes without a length prefix.
+    /// </summary>
+    private static ReadOnlySpan<byte> DomainSeparator => "Cashu_MintQuoteSig_v1"u8;
+
     public static string SignMintQuote(
         this PrivKey pk,
         string quote,
@@ -18,27 +25,65 @@ public static class MintQuoteSigner
         return pk.Key.SignBIP340(hash).ToHex();
     }
 
+    /// <summary>
+    /// Builds the NUT-20 message committing to the quote id and every output:
+    /// <c>"Cashu_MintQuoteSig_v1" || len32(quote) || quote || (len32(amount) || amount ||
+    /// len32(B_) || B_)*</c>, where <c>len32</c> is a 32-bit big-endian byte length.
+    /// </summary>
     internal static byte[] GetMessageToSign(string quote, IEnumerable<BlindedMessage> messages)
     {
-        var sb = new StringBuilder();
-        sb.Append(quote);
-        var msgs = messages as IReadOnlyList<BlindedMessage> ?? messages.ToList();
-        foreach (var blindedMessage in msgs)
+        var writer = new ArrayBufferWriter<byte>(256);
+
+        writer.Write(DomainSeparator);
+        WriteLengthPrefixed(writer, Encoding.UTF8.GetBytes(quote));
+
+        foreach (var blindedMessage in messages)
         {
-            sb.Append(blindedMessage.B_);
+            WriteLengthPrefixed(writer, ToMinimalBigEndian(blindedMessage.Amount));
+            // The raw point, not its hex string.
+            WriteLengthPrefixed(writer, blindedMessage.B_.Key.ToBytes());
         }
-        return Encoding.UTF8.GetBytes(sb.ToString());
+
+        return writer.WrittenSpan.ToArray();
+    }
+
+    private static void WriteLengthPrefixed(IBufferWriter<byte> writer, ReadOnlySpan<byte> value)
+    {
+        var span = writer.GetSpan(4 + value.Length);
+        BinaryPrimitives.WriteUInt32BigEndian(span, (uint)value.Length);
+        value.CopyTo(span[4..]);
+        writer.Advance(4 + value.Length);
+    }
+
+    /// <summary>
+    /// Canonical minimal big-endian encoding: no leading zero bytes, and zero is empty.
+    /// </summary>
+    internal static byte[] ToMinimalBigEndian(ulong amount)
+    {
+        if (amount == 0)
+        {
+            return [];
+        }
+
+        Span<byte> buffer = stackalloc byte[sizeof(ulong)];
+        BinaryPrimitives.WriteUInt64BigEndian(buffer, amount);
+
+        var start = 0;
+        while (buffer[start] == 0)
+        {
+            start++;
+        }
+
+        return buffer[start..].ToArray();
     }
 
     public static bool VerifySignature(this PostMintRequest quote, PubKey pk)
     {
-        ArgumentNullException.ThrowIfNull(quote.Signature,  nameof(quote.Signature));
+        ArgumentNullException.ThrowIfNull(quote.Signature, nameof(quote.Signature));
         var msg = GetMessageToSign(quote.Quote, quote.Outputs);
         var hash = SHA256.HashData(msg);
         var xonly = pk.Key.ToXOnlyPubKey();
-        if (!SecpSchnorrSignature.TryCreate(
-                Convert.FromHexString(quote.Signature), out var sig)
-            )
+        if (!SecpSchnorrSignature.TryCreate(Convert.FromHexString(quote.Signature), out var sig))
         {
             return false;
         }

--- a/DotNut/NUT20/MintQuoteSigner.cs
+++ b/DotNut/NUT20/MintQuoteSigner.cs
@@ -14,6 +14,12 @@ public static class MintQuoteSigner
     /// </summary>
     private static ReadOnlySpan<byte> DomainSeparator => "Cashu_MintQuoteSig_v1"u8;
 
+    /// <summary>
+    /// "Signature for mint request invalid", the error a mint returns when it rejects the
+    /// quote signature.
+    /// </summary>
+    internal const int InvalidSignatureErrorCode = 20008;
+
     public static string SignMintQuote(
         this PrivKey pk,
         string quote,
@@ -47,6 +53,39 @@ public static class MintQuoteSigner
         return writer.WrittenSpan.ToArray();
     }
 
+    /// <summary>
+    /// Signs with the message format used before cashubtc/nuts@b969c4aa. Only for retrying
+    /// against mints that have not upgraded yet — mints that understand the current format
+    /// still accept this one, but not the other way round.
+    /// </summary>
+    public static string SignMintQuoteLegacy(
+        this PrivKey pk,
+        string quote,
+        List<BlindedMessage> blindedMessages
+    )
+    {
+        var msg = GetLegacyMessageToSign(quote, blindedMessages);
+        var hash = SHA256.HashData(msg);
+        return pk.Key.SignBIP340(hash).ToHex();
+    }
+
+    /// <summary>
+    /// The superseded message: the quote id and the hex of every output, concatenated as UTF-8.
+    /// </summary>
+    internal static byte[] GetLegacyMessageToSign(
+        string quote,
+        IEnumerable<BlindedMessage> messages
+    )
+    {
+        var sb = new StringBuilder();
+        sb.Append(quote);
+        foreach (var blindedMessage in messages)
+        {
+            sb.Append(blindedMessage.B_);
+        }
+        return Encoding.UTF8.GetBytes(sb.ToString());
+    }
+
     private static void WriteLengthPrefixed(IBufferWriter<byte> writer, ReadOnlySpan<byte> value)
     {
         var span = writer.GetSpan(4 + value.Length);
@@ -77,16 +116,28 @@ public static class MintQuoteSigner
         return buffer[start..].ToArray();
     }
 
-    public static bool VerifySignature(this PostMintRequest quote, PubKey pk)
+    /// <param name="allowLegacy">
+    /// Also accept a signature over the superseded message, the way cdk and nutshell do, so
+    /// that wallets which have not upgraded can still mint.
+    /// </param>
+    public static bool VerifySignature(this PostMintRequest quote, PubKey pk, bool allowLegacy = true)
     {
         ArgumentNullException.ThrowIfNull(quote.Signature, nameof(quote.Signature));
-        var msg = GetMessageToSign(quote.Quote, quote.Outputs);
-        var hash = SHA256.HashData(msg);
-        var xonly = pk.Key.ToXOnlyPubKey();
         if (!SecpSchnorrSignature.TryCreate(Convert.FromHexString(quote.Signature), out var sig))
         {
             return false;
         }
-        return xonly.SigVerifyBIP340(sig, hash);
+
+        var xonly = pk.Key.ToXOnlyPubKey();
+        if (xonly.SigVerifyBIP340(sig, SHA256.HashData(GetMessageToSign(quote.Quote, quote.Outputs))))
+        {
+            return true;
+        }
+
+        return allowLegacy
+            && xonly.SigVerifyBIP340(
+                sig,
+                SHA256.HashData(GetLegacyMessageToSign(quote.Quote, quote.Outputs))
+            );
     }
 }

--- a/DotNut/NUT20/MintQuoteSigner.cs
+++ b/DotNut/NUT20/MintQuoteSigner.cs
@@ -14,12 +14,6 @@ public static class MintQuoteSigner
     /// </summary>
     private static ReadOnlySpan<byte> DomainSeparator => "Cashu_MintQuoteSig_v1"u8;
 
-    /// <summary>
-    /// "Signature for mint request invalid", the error a mint returns when it rejects the
-    /// quote signature.
-    /// </summary>
-    internal const int InvalidSignatureErrorCode = 20008;
-
     public static string SignMintQuote(
         this PrivKey pk,
         string quote,

--- a/DotNut/NUT29/BatchedMintQuoteSigner.cs
+++ b/DotNut/NUT29/BatchedMintQuoteSigner.cs
@@ -1,0 +1,40 @@
+using DotNut.ApiModels;
+
+namespace DotNut;
+
+public static class BatchedMintQuoteSigner
+{
+    /// <summary>
+    /// Signs the locked quotes of a batch. Each signature is an ordinary NUT-20 signature over
+    /// one quote id and the batch's whole <c>outputs</c> array — the outputs are one consolidated
+    /// set, not partitioned per quote.
+    /// </summary>
+    /// <param name="keysByQuoteId">
+    /// Keys for the locked quotes, by quote id. Quotes missing from this get a null signature,
+    /// as the spec requires for unlocked quotes.
+    /// </param>
+    public static PostBatchedMintRequest Sign(
+        this PostBatchedMintRequest request,
+        IReadOnlyDictionary<string, PrivKey> keysByQuoteId
+    )
+    {
+        var outputs = request.Outputs.ToList();
+        var signatures = new string?[request.QuoteIds.Length];
+        var anyLocked = false;
+
+        for (var i = 0; i < request.QuoteIds.Length; i++)
+        {
+            if (!keysByQuoteId.TryGetValue(request.QuoteIds[i], out var key))
+            {
+                continue;
+            }
+
+            signatures[i] = key.SignMintQuote(request.QuoteIds[i], outputs);
+            anyLocked = true;
+        }
+
+        // The field may be left out entirely when no quote is locked.
+        request.Signatures = anyLocked ? signatures : null;
+        return request;
+    }
+}


### PR DESCRIPTION
Aligns the mint quote signature with cashubtc/nuts#b969c4aa, which replaced the concatenated quote id and hex outputs with a domain-separated, length-prefixed commitment over raw bytes:

```
msg_to_sign = b"Cashu_MintQuoteSig_v1"
              || len32(quote) || quote
              || for each output i: len32(amount_i) || amount_i || len32(B_i) || B_i
```

Amounts are canonical minimal big-endian (`0` → empty, `256` → `0x0100`) and `B_` is the decoded point, not its hex string. The old test vector was signed over the old message, so it is replaced with the one from `tests/20-test.md`; the test asserts `msg_to_sign` and its hash directly, so a mistake in the length prefixes shows up on its own rather than as a failed signature.

### Legacy fallback

No released cdk-mintd understands the new message. The change is on `main` (`56fb4d7b`) but in no tag up to v0.17.3, so signing only the new way makes NUT-20 minting fail against every mint deployed today — including the one CI starts.

So the handlers sign the current message first and, when the mint answers error `20008`, sign the same outputs the old way and retry once. Nothing is issued on a rejected signature, so the retry cannot double-spend. Verification accepts either, with `allowLegacy: false` to refuse.

This mirrors what the reference implementations did: cdk added `sign_legacy` for wallets plus a legacy branch in `verify_signature`, and nutshell has verified both since 0.20.2. Removable once mints without the current format are gone.

Verified against live mints:

| mint | result |
|---|---|
| cdk-mintd 0.15.1 (what CI runs, `latest-amd64`) | passes |
| cdk-mintd 0.17.3 (latest release) | passes |

### NUT-29

NUT-29 defines no message of its own — `signatures[i]` is a NUT-20 signature over `quotes[i]` and the batch's whole `outputs` array, since the outputs are one consolidated set rather than partitioned per quote. The models were already there but nothing filled `Signatures`, so this adds `PostBatchedMintRequest.Sign(keysByQuoteId)`: one entry per quote, `null` for unlocked ones, field omitted when nothing is locked. Covered by the vector from `tests/29-tests.md`.

### Also

Error codes moved off `MintQuoteSigner` into `CashuErrorCodes`, carrying the full table from `error_codes.md` — including `12003` and NUT-29's `11016`/`11017`, which upstream added recently.

---

Unit tests: 126 passing.
