### PR TITLE
NUT-04/23/25: mint quote accounting fields

### DIFF
--- a/DotNut.Tests/Unit/Nut23Tests.cs
+++ b/DotNut.Tests/Unit/Nut23Tests.cs
@@ -1,0 +1,110 @@
+using System.Text.Json;
+using DotNut.ApiModels;
+using DotNut.ApiModels.Mint.bolt12;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut23Tests
+{
+    [Fact]
+    public void ParsesTheAccountingFields()
+    {
+        // Example from 23.md, after the NUT-04 accounting change.
+        const string json = """
+            {
+              "quote": "019e6d5a-2347-7000-8322-05d51d498303",
+              "request": "lnbc100n1pj4apw9...",
+              "unit": "sat",
+              "method": "bolt11",
+              "amount_paid": 100,
+              "amount_issued": 40,
+              "updated_at": 1701704657,
+              "state": "PAID",
+              "expiry": 1701704757
+            }
+            """;
+
+        var quote = JsonSerializer.Deserialize<PostMintQuoteBolt11Response>(json);
+        Assert.NotNull(quote);
+
+        Assert.Equal((ulong)100, quote.AmountPaid);
+        Assert.Equal((ulong)40, quote.AmountIssued);
+        Assert.Equal(1701704657, quote.UpdatedAt);
+        Assert.Equal("bolt11", quote.Method);
+
+        // Partially issued: 60 left, which "PAID" alone cannot express.
+        Assert.Equal((ulong)60, quote.Mintable);
+    }
+
+    [Fact]
+    public void MintableIsUnknownWithoutTheAccountingFields()
+    {
+        // A mint that has not caught up sends state only.
+        const string json = """
+            {
+              "quote": "019e6d5a-2347-7000-8322-05d51d498303",
+              "request": "lnbc100n1pj4apw9...",
+              "state": "UNPAID"
+            }
+            """;
+
+        var quote = JsonSerializer.Deserialize<PostMintQuoteBolt11Response>(json);
+        Assert.NotNull(quote);
+
+        Assert.Null(quote.Mintable);
+        Assert.Equal("UNPAID", quote.State);
+    }
+
+    [Fact]
+    public void MintableIsZeroWhenEverythingWasIssued()
+    {
+        var quote = new PostMintQuoteBolt11Response { AmountPaid = 100, AmountIssued = 100 };
+        Assert.Equal((ulong)0, quote.Mintable);
+
+        // amount_issued must never exceed amount_paid, but do not underflow if a mint gets it wrong.
+        var broken = new PostMintQuoteBolt11Response { AmountPaid = 10, AmountIssued = 40 };
+        Assert.Equal((ulong)0, broken.Mintable);
+    }
+
+    [Fact]
+    public void Bolt12QuoteExposesTheSameAccounting()
+    {
+        const string json = """
+            {
+              "quote": "019e6d5a-2347-7000-8449-370fefb42fed",
+              "request": "lno1...",
+              "unit": "sat",
+              "method": "bolt12",
+              "pubkey": "03d56ce4e446a85bbdaa547b4ec2b073d40ff802831352b8272b7dd7a4de5a7cac",
+              "amount_paid": 500,
+              "amount_issued": 0,
+              "updated_at": 1701704657
+            }
+            """;
+
+        var quote = JsonSerializer.Deserialize<PostMintQuoteBolt12Response>(json);
+        Assert.NotNull(quote);
+
+        Assert.Equal((ulong)500, quote.Mintable);
+        Assert.Equal(1701704657, quote.UpdatedAt);
+        Assert.Equal("bolt12", quote.Method);
+    }
+
+    [Fact]
+    public void StateStaysOptionalOnTheWire()
+    {
+        // state is deprecated, so it must not be emitted when unset.
+        var json = JsonSerializer.Serialize(
+            new PostMintQuoteBolt11Response
+            {
+                Quote = "q",
+                Request = "r",
+                AmountPaid = 1,
+                AmountIssued = 0,
+            }
+        );
+
+        Assert.DoesNotContain("state", json);
+        Assert.Contains("amount_paid", json);
+    }
+}

--- a/DotNut/Abstractions/Handlers/MintHandlerBolt11.cs
+++ b/DotNut/Abstractions/Handlers/MintHandlerBolt11.cs
@@ -9,6 +9,7 @@ public class MintHandlerBolt11(
     List<OutputData> outputs
 ) : IMintHandler<PostMintQuoteBolt11Response, List<Proof>>
 {
+    private PostMintQuoteBolt11Response _quote = postMintQuoteBolt11Response;
     private string? _signature;
 
     public IMintHandler<PostMintQuoteBolt11Response, List<Proof>> WithSignature(string signature)
@@ -25,23 +26,41 @@ public class MintHandlerBolt11(
     public IMintHandler<PostMintQuoteBolt11Response, List<Proof>> SignWithPrivkey(PrivKey privkey)
     {
         this._signature = privkey.SignMintQuote(
-            postMintQuoteBolt11Response.Quote,
+            _quote.Quote,
             outputs.Select(o => o.BlindedMessage).ToList()
         );
         return this;
     }
 
-    public PostMintQuoteBolt11Response GetQuote() => postMintQuoteBolt11Response;
+    public PostMintQuoteBolt11Response GetQuote() => _quote;
 
     public List<OutputData> GetOutputs() => outputs;
 
+    public async Task<PostMintQuoteBolt11Response> RefreshQuote(CancellationToken ct = default)
+    {
+        var client = await wallet.GetMintApi(ct);
+        var fresh = await client.CheckMintQuote<PostMintQuoteBolt11Response>(
+            "bolt11",
+            _quote.Quote,
+            ct
+        );
+
+        if (_quote.UpdatedAt is { } held && fresh.UpdatedAt is { } incoming && incoming < held)
+        {
+            return _quote;
+        }
+
+        _quote = fresh;
+        return _quote;
+    }
+
     public async Task<List<Proof>> Mint(CancellationToken ct = default)
     {
-        if (postMintQuoteBolt11Response.PubKey is not null && this._signature is null)
+        if (_quote.PubKey is not null && this._signature is null)
         {
             throw new ArgumentNullException(
                 nameof(_signature),
-                $"Signature for mint quote {postMintQuoteBolt11Response.Quote} is required!"
+                $"Signature for mint quote {_quote.Quote} is required!"
             );
         }
         var client = await wallet.GetMintApi(ct);
@@ -49,7 +68,7 @@ public class MintHandlerBolt11(
         var req = new PostMintRequest
         {
             Outputs = outputs.Select(o => o.BlindedMessage).ToArray(),
-            Quote = postMintQuoteBolt11Response.Quote,
+            Quote = _quote.Quote,
             Signature = _signature,
         };
 

--- a/DotNut/Abstractions/Handlers/MintHandlerBolt12.cs
+++ b/DotNut/Abstractions/Handlers/MintHandlerBolt12.cs
@@ -10,6 +10,7 @@ public class MintHandlerBolt12(
     List<OutputData> outputs
 ) : IMintHandler<PostMintQuoteBolt12Response, List<Proof>>
 {
+    private PostMintQuoteBolt12Response _quote = quote;
     private string? _signature;
 
     public IMintHandler<PostMintQuoteBolt12Response, List<Proof>> WithSignature(string signature)
@@ -26,15 +27,33 @@ public class MintHandlerBolt12(
     public IMintHandler<PostMintQuoteBolt12Response, List<Proof>> SignWithPrivkey(PrivKey privkey)
     {
         this._signature = privkey.SignMintQuote(
-            quote.Quote,
+            _quote.Quote,
             outputs.Select(o => o.BlindedMessage).ToList()
         );
         return this;
     }
 
-    public PostMintQuoteBolt12Response GetQuote() => quote;
+    public PostMintQuoteBolt12Response GetQuote() => _quote;
 
     public List<OutputData> GetOutputs() => outputs;
+
+    public async Task<PostMintQuoteBolt12Response> RefreshQuote(CancellationToken ct = default)
+    {
+        var client = await wallet.GetMintApi(ct);
+        var fresh = await client.CheckMintQuote<PostMintQuoteBolt12Response>(
+            "bolt12",
+            _quote.Quote,
+            ct
+        );
+
+        if (_quote.UpdatedAt is { } held && fresh.UpdatedAt is { } incoming && incoming < held)
+        {
+            return _quote;
+        }
+
+        _quote = fresh;
+        return _quote;
+    }
 
     public async Task<List<Proof>> Mint(CancellationToken ct = default)
     {
@@ -42,7 +61,7 @@ public class MintHandlerBolt12(
         {
             throw new ArgumentNullException(
                 nameof(this._signature),
-                $"Signature for mint quote {quote.Quote} is required!"
+                $"Signature for mint quote {_quote.Quote} is required!"
             );
         }
 
@@ -50,7 +69,7 @@ public class MintHandlerBolt12(
         var req = new PostMintRequest
         {
             Outputs = outputs.Select(o => o.BlindedMessage).ToArray(),
-            Quote = quote.Quote,
+            Quote = _quote.Quote,
             Signature = _signature,
         };
 

--- a/DotNut/Abstractions/Interfaces/IMintHandler.cs
+++ b/DotNut/Abstractions/Interfaces/IMintHandler.cs
@@ -11,5 +11,12 @@ public interface IMintHandler<TQuote, TResponse> : IMintHandler
     TQuote GetQuote();
     List<OutputData> GetOutputs();
 
+    /// <summary>
+    /// Re-reads the quote from the mint and returns it. A response older than the one already
+    /// held is discarded, as NUT-04 requires: mints bump <c>updated_at</c> on every change to
+    /// the amounts, and a wallet must not let a stale reply walk those amounts backwards.
+    /// </summary>
+    Task<TQuote> RefreshQuote(CancellationToken ct = default);
+
     Task<TResponse> Mint(CancellationToken ct = default);
 }

--- a/DotNut/ApiModels/Mint/bolt11/PostMintQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Mint/bolt11/PostMintQuoteBolt11Response.cs
@@ -10,8 +10,44 @@ public class PostMintQuoteBolt11Response
     [JsonPropertyName("request")]
     public string Request { get; set; }
 
+    /// <summary>
+    /// Deprecated since NUT-23 gained the accounting fields. Prefer <see cref="AmountPaid"/> and
+    /// <see cref="AmountIssued"/>, which also describe partially issued quotes.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("state")]
-    public string State { get; set; }
+    public string? State { get; set; }
+
+    /// <summary>Total paid to the mint for this quote, in <see cref="Unit"/>.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("amount_paid")]
+    public ulong? AmountPaid { get; set; }
+
+    /// <summary>Total already issued against this quote, in <see cref="Unit"/>.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("amount_issued")]
+    public ulong? AmountIssued { get; set; }
+
+    /// <summary>Unix timestamp of the last change to the amounts. Increases monotonically.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("updated_at")]
+    public long? UpdatedAt { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
+
+    /// <summary>
+    /// What can still be minted: <c>amount_paid - amount_issued</c>. Null when the mint does not
+    /// send the accounting fields, in which case only <see cref="State"/> is available.
+    /// </summary>
+    [JsonIgnore]
+    public ulong? Mintable =>
+        AmountPaid is { } paid && AmountIssued is { } issued
+            ? paid > issued
+                ? paid - issued
+                : 0
+            : null;
 
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("expiry")]

--- a/DotNut/ApiModels/Mint/bolt12/PostMintQuoteBolt12Response.cs
+++ b/DotNut/ApiModels/Mint/bolt12/PostMintQuoteBolt12Response.cs
@@ -29,4 +29,17 @@ public class PostMintQuoteBolt12Response
 
     [JsonPropertyName("amount_issued")]
     public ulong AmountIssued { get; set; }
+
+    /// <summary>Unix timestamp of the last change to the amounts. Increases monotonically.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("updated_at")]
+    public long? UpdatedAt { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
+
+    /// <summary>What can still be minted: <c>amount_paid - amount_issued</c>.</summary>
+    [JsonIgnore]
+    public ulong Mintable => AmountPaid > AmountIssued ? AmountPaid - AmountIssued : 0;
 }


### PR DESCRIPTION
NUT-04 replaced the paid/unpaid view of a mint quote with running totals — `amount_paid`, `amount_issued`, `updated_at` — and deprecated `state`. What is mintable is now `amount_paid - amount_issued`, which `state` cannot express once a quote has been partially issued.

Adds the four fields (plus `method`) to `PostMintQuoteBolt11Response` and the two missing ones to `PostMintQuoteBolt12Response`, with a `Mintable` helper on both.

### All of them are optional, on purpose

cdk-mintd 0.17.3 still answers a mint quote with `state` alone:

```json
{
  "quote": "019fc475-2c9f-7a13-a349-aa00ea59267b",
  "request": "lnbc210n1p4xlwa3...",
  "amount": 21,
  "unit": "sat",
  "state": "UNPAID",
  "expiry": 1785711041
}
```

The spec says mints **MUST** send the accounting fields, but nothing deployed does yet. So they are nullable and `Mintable` returns null when they are absent, rather than a zero that would read as "nothing left to mint". Callers that get null fall back to `State`.

`State` also became nullable and is no longer written when unset, since it is deprecated.

### RefreshQuote

NUT-04 requires that a wallet holding a quote across several replies never lets a stale response walk the amounts backwards:

> Wallets that receive multiple responses for the same quote **MUST NOT** replace locally stored quote data with a response whose `updated_at` is lower than the latest processed value

`IMintHandler.RefreshQuote` re-reads the quote and discards a response older than the one already held, which gives that rule somewhere to live — the handler is the only place in the library that keeps a quote around.

### Not in this PR

The melt quote responses also gained `method`, and `fee_reserve` became optional — those belong with the rest of the NUT-05 changes (`prefer_async` and friends).

---

Unit tests: 114 passing. Minting bolt11, bolt12 and deterministic still verified against cdk-mintd 0.17.3.