### PR TITLE
NUT-05: prefer_async and the new melt quote fields

### DIFF
--- a/DotNut.Tests/Unit/Nut05Tests.cs
+++ b/DotNut.Tests/Unit/Nut05Tests.cs
@@ -1,0 +1,63 @@
+using System.Text.Json;
+using DotNut.Abstractions;
+using DotNut.ApiModels;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut05Tests
+{
+    [Fact]
+    public void PreferAsyncIsOnlySentWhenAsked()
+    {
+        var request = new PostMeltRequest { Quote = "q", Inputs = [] };
+        Assert.DoesNotContain("prefer_async", JsonSerializer.Serialize(request));
+
+        request.PreferAsync = true;
+        Assert.Contains("\"prefer_async\":true", JsonSerializer.Serialize(request));
+    }
+
+    [Fact]
+    public void ParsesMethodAndRequestOnTheMeltQuote()
+    {
+        // Example from 23.md after the NUT-05 change.
+        const string json = """
+            {
+              "quote": "019e6d5a-2347-7000-8449-370fefb42fed",
+              "request": "lnbc100n1p3kdrv5sp5...",
+              "amount": 10,
+              "unit": "sat",
+              "fee_reserve": 2,
+              "method": "bolt11",
+              "state": "PENDING",
+              "expiry": 1701704757
+            }
+            """;
+
+        var quote = JsonSerializer.Deserialize<PostMeltQuoteBolt11Response>(json);
+        Assert.NotNull(quote);
+
+        Assert.Equal("bolt11", quote.Method);
+        Assert.Equal("lnbc100n1p3kdrv5sp5...", quote.Request);
+        Assert.Equal((ulong)2, quote.FeeReserve);
+        Assert.Equal("sat", quote.Unit);
+    }
+
+    [Fact]
+    public void FeeReserveMayBeOmitted()
+    {
+        const string json = """
+            {
+              "quote": "019e6d5a-2347-7000-8449-370fefb42fed",
+              "amount": 10,
+              "state": "UNPAID"
+            }
+            """;
+
+        var quote = JsonSerializer.Deserialize<PostMeltQuoteBolt11Response>(json);
+        Assert.NotNull(quote);
+
+        // Absent means no reserve, which is what the melt builder treats it as.
+        Assert.Null(quote.FeeReserve);
+        Assert.Equal(0, Utils.CalculateNumberOfBlankOutputs(quote.FeeReserve ?? 0));
+    }
+}

--- a/DotNut.Tests/Unit/UnitTest1.cs
+++ b/DotNut.Tests/Unit/UnitTest1.cs
@@ -106,7 +106,7 @@ public class UnitTest1
         Assert.NotNull(response);
         Assert.Equal("melt-quote-id", response.Quote);
         Assert.Equal((ulong)1000, response.Amount);
-        Assert.Equal(50, response.FeeReserve);
+        Assert.Equal((ulong)50, response.FeeReserve);
         Assert.Equal("PAID", response.State);
         Assert.Null(response.Expiry);
         Assert.Equal("test-preimage", response.PaymentPreimage);
@@ -126,7 +126,7 @@ public class UnitTest1
         Assert.NotNull(response2);
         Assert.Equal("melt-quote-id-2", response2.Quote);
         Assert.Equal((ulong)500, response2.Amount);
-        Assert.Equal(25, response2.FeeReserve);
+        Assert.Equal((ulong)25, response2.FeeReserve);
         Assert.Equal("UNPAID", response2.State);
         Assert.Null(response2.Expiry);
         Assert.Null(response2.PaymentPreimage);
@@ -147,7 +147,7 @@ public class UnitTest1
         Assert.NotNull(response3);
         Assert.Equal("melt-quote-id-3", response3.Quote);
         Assert.Equal((ulong)2000, response3.Amount);
-        Assert.Equal(100, response3.FeeReserve);
+        Assert.Equal((ulong)100, response3.FeeReserve);
         Assert.Equal("PENDING", response3.State);
         Assert.Equal(1640995200, response3.Expiry);
         Assert.Null(response3.PaymentPreimage);

--- a/DotNut/Abstractions/Handlers/MeltHandlerBolt11.cs
+++ b/DotNut/Abstractions/Handlers/MeltHandlerBolt11.cs
@@ -14,7 +14,11 @@ public class MeltHandlerBolt11(
 
     public List<OutputData> GetBlankOutputs() => blankOutputs;
 
-    public async Task<List<Proof>> Melt(IEnumerable<Proof> inputs, CancellationToken ct = default)
+    public async Task<List<Proof>> Melt(
+        IEnumerable<Proof> inputs,
+        bool preferAsync = false,
+        CancellationToken ct = default
+    )
     {
         //we're operating on copy here since later the proof state is mutated in stripFingerprints
         var proofs = inputs.DeepCopyList();
@@ -35,6 +39,8 @@ public class MeltHandlerBolt11(
             Quote = quote.Quote,
             Inputs = proofs.ToArray(),
             Outputs = blankOutputs.Select(bo => bo.BlindedMessage).ToArray(),
+            // Only sent when asked for, so mints that predate the field see no change.
+            PreferAsync = preferAsync ? true : null,
         };
 
         var res = await client.Melt<PostMeltQuoteBolt11Response, PostMeltRequest>(

--- a/DotNut/Abstractions/Handlers/MeltHandlerBolt12.cs
+++ b/DotNut/Abstractions/Handlers/MeltHandlerBolt12.cs
@@ -13,7 +13,11 @@ public class MeltHandlerBolt12(
 {
     public PostMeltQuoteBolt12Response GetQuote() => quote;
 
-    public async Task<List<Proof>> Melt(IEnumerable<Proof> inputs, CancellationToken ct = default)
+    public async Task<List<Proof>> Melt(
+        IEnumerable<Proof> inputs,
+        bool preferAsync = false,
+        CancellationToken ct = default
+    )
     {
         //we're operating on copy here since later the proof state is mutated in stripFingerprints
         var proofs = inputs.DeepCopyList();
@@ -33,6 +37,8 @@ public class MeltHandlerBolt12(
             Quote = quote.Quote,
             Inputs = proofs.ToArray(),
             Outputs = blankOutputs.Select(bo => bo.BlindedMessage).ToArray(),
+            // Only sent when asked for, so mints that predate the field see no change.
+            PreferAsync = preferAsync ? true : null,
         };
 
         var res = await client.Melt<PostMeltQuoteBolt12Response, PostMeltRequest>(

--- a/DotNut/Abstractions/Interfaces/IMeltHandler.cs
+++ b/DotNut/Abstractions/Interfaces/IMeltHandler.cs
@@ -5,5 +5,18 @@ public interface IMeltHandler;
 public interface IMeltHandler<TQuote, TResponse> : IMeltHandler
 {
     TQuote GetQuote();
-    Task<TResponse> Melt(IEnumerable<Proof> inputs, CancellationToken ct = default);
+
+    /// <summary>
+    /// Pays the quote.
+    /// </summary>
+    /// <param name="preferAsync">
+    /// Ask the mint to return once the request validates rather than once the payment settles,
+    /// leaving the quote PENDING. Poll the quote or subscribe over websockets to follow it.
+    /// Mints that do not support this for the method ignore it and pay synchronously.
+    /// </param>
+    Task<TResponse> Melt(
+        IEnumerable<Proof> inputs,
+        bool preferAsync = false,
+        CancellationToken ct = default
+    );
 }

--- a/DotNut/Abstractions/MeltQuoteBuilder.cs
+++ b/DotNut/Abstractions/MeltQuoteBuilder.cs
@@ -84,7 +84,7 @@ class MeltQuoteBuilder : IMeltQuoteBuilder
 
         if (_blankOutputs == null)
         {
-            var outputsAmount = Utils.CalculateNumberOfBlankOutputs((ulong)quote.FeeReserve);
+            var outputsAmount = Utils.CalculateNumberOfBlankOutputs(quote.FeeReserve ?? 0);
             var amounts = Enumerable.Repeat(1UL, outputsAmount).ToList();
             this._blankOutputs = await this._wallet.CreateOutputs(amounts, this._unit, ct);
         }
@@ -116,7 +116,7 @@ class MeltQuoteBuilder : IMeltQuoteBuilder
 
         if (_blankOutputs == null)
         {
-            var outputsAmount = Utils.CalculateNumberOfBlankOutputs((ulong)quote.FeeReserve);
+            var outputsAmount = Utils.CalculateNumberOfBlankOutputs(quote.FeeReserve ?? 0);
             var amounts = Enumerable.Repeat(1UL, outputsAmount).ToList();
             this._blankOutputs = await this._wallet.CreateOutputs(amounts, this._unit, ct);
         }

--- a/DotNut/ApiModels/Melt/PostMeltRequest.cs
+++ b/DotNut/ApiModels/Melt/PostMeltRequest.cs
@@ -13,4 +13,14 @@ public class PostMeltRequest
     [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("outputs")]
     public BlindedMessage[]? Outputs { get; set; }
+
+    /// <summary>
+    /// Asks the mint to return as soon as the request validates, leaving the quote PENDING while
+    /// the payment runs. Replaces the <c>Prefer: respond-async</c> header. Ignored by mints that
+    /// do not support it for the method, and unnecessary for methods whose NUT requires async
+    /// execution anyway.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("prefer_async")]
+    public bool? PreferAsync { get; set; }
 }

--- a/DotNut/ApiModels/Melt/bolt11/PostMeltQuoteBolt11Response.cs
+++ b/DotNut/ApiModels/Melt/bolt11/PostMeltQuoteBolt11Response.cs
@@ -7,11 +7,29 @@ public class PostMeltQuoteBolt11Response
     [JsonPropertyName("quote")]
     public string Quote { get; set; }
 
+    /// <summary>The method-specific payment target the quote routes to.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("request")]
+    public string? Request { get; set; }
+
     [JsonPropertyName("amount")]
     public ulong Amount { get; set; }
 
+    /// <summary>
+    /// Extra reserve for the method, on top of <see cref="Amount"/>. Optional since NUT-05;
+    /// the inputs have to cover <c>amount + fee_reserve + input fee</c> (NUT-02).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("fee_reserve")]
-    public int FeeReserve { get; set; }
+    public ulong? FeeReserve { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("unit")]
+    public string? Unit { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
 
     [JsonPropertyName("state")]
     public string State { get; set; }

--- a/DotNut/ApiModels/Melt/bolt12/PostMeltQuoteBolt12Response.cs
+++ b/DotNut/ApiModels/Melt/bolt12/PostMeltQuoteBolt12Response.cs
@@ -16,8 +16,17 @@ public class PostMeltQuoteBolt12Response
     [JsonPropertyName("unit")]
     public string Unit { get; set; }
 
+    /// <summary>
+    /// Extra reserve for the method, on top of <see cref="Amount"/>. Optional since NUT-05;
+    /// the inputs have to cover <c>amount + fee_reserve + input fee</c> (NUT-02).
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
     [JsonPropertyName("fee_reserve")]
-    public ulong FeeReserve { get; set; }
+    public ulong? FeeReserve { get; set; }
+
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("method")]
+    public string? Method { get; set; }
 
     [JsonPropertyName("state")]
     public string State { get; set; }


### PR DESCRIPTION
### prefer_async

NUT-05 moved the async request out of the `Prefer: respond-async` header and into `prefer_async` on the melt request body. `Melt` takes a `preferAsync` flag:

```csharp
await handler.Melt(proofs, preferAsync: true);
```

The field is only serialised when asked for, so mints that predate it see a request identical to today's. Methods whose own NUT mandates async execution — NUT-30 onchain, for one — are processed that way regardless and do not need the flag.

### fee_reserve is optional now

It was `int` on bolt11 and `ulong` on bolt12; both become `ulong?`. An absent reserve means none, which is how `MeltQuoteBuilder` now sizes the blank outputs (`quote.FeeReserve ?? 0`) rather than throwing on the cast.

Worth noting for reviewers, since it is a breaking signature change for anyone reading `FeeReserve` — the melt quote responses are public API.

### Fields that were missing

`method` on both quote responses, plus `request` and `unit` on bolt11.

### Not in this PR

The spec also spells out that inputs must cover `amount + fee_reserve + input_fee` per NUT-02. `MeltQuoteBuilder` already reserves for the fee; whether proof selection accounts for the NUT-02 input fee is a separate question and not something this PR changes.

---

Unit tests: 112 passing. All 11 melt tests verified against a fresh cdk-mintd 0.17.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for requesting asynchronous melt processing.
  - Added optional melt quote metadata, including payment method, unit, and request details.
  - Added support for responses where the fee reserve is not provided.

- **Bug Fixes**
  - Corrected fee reserve handling when the value is omitted, treating it as zero where appropriate.
  - Improved JSON serialization so optional fields are omitted when unavailable.

- **Tests**
  - Added coverage for asynchronous requests, quote metadata parsing, and omitted fee reserves.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->