### PR TITLE
NUT-21/22: match protected endpoints without regex

### DIFF
--- a/DotNut.Tests/Unit/Nut22PathMatchingTests.cs
+++ b/DotNut.Tests/Unit/Nut22PathMatchingTests.cs
@@ -1,0 +1,97 @@
+using System.Text.Json;
+using DotNut.Abstractions;
+using DotNut.ApiModels;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut22PathMatchingTests
+{
+    private static MintInfo InfoWith(params (string Method, string Path)[] endpoints)
+    {
+        var entries = string.Join(
+            ",",
+            endpoints.Select(e =>
+                JsonSerializer.Serialize(
+                    new ProtectedEndpointSpec { Method = e.Method, Path = e.Path }
+                )
+            )
+        );
+
+        var info = JsonSerializer.Deserialize<GetInfoResponse>(
+            "{\"nuts\":{\"22\":{\"protected_endpoints\":[" + entries + "]}}}"
+        );
+
+        return new MintInfo(info!);
+    }
+
+    [Fact]
+    public void ExactPathMatchesOnlyItself()
+    {
+        var info = InfoWith(("POST", "/v1/auth/blind/mint"));
+
+        Assert.True(info.RequiresBlindAuthToken("/v1/auth/blind/mint"));
+        Assert.False(info.RequiresBlindAuthToken("/v1/auth/blind/mint/extra"));
+        Assert.False(info.RequiresBlindAuthToken("/prefix/v1/auth/blind/mint"));
+    }
+
+    [Fact]
+    public void TrailingStarMatchesByPrefix()
+    {
+        var info = InfoWith(("POST", "/v1/mint/*"));
+
+        Assert.True(info.RequiresBlindAuthToken("/v1/mint/quote/bolt11"));
+        Assert.True(info.RequiresBlindAuthToken("/v1/mint/bolt11"));
+        Assert.False(info.RequiresBlindAuthToken("/v1/melt/bolt11"));
+        // The prefix includes the slash, so /v1/mintxyz is a different endpoint.
+        Assert.False(info.RequiresBlindAuthToken("/v1/mintxyz"));
+    }
+
+    [Fact]
+    public void StarNeedNotFollowASlash()
+    {
+        var info = InfoWith(("POST", "/v1/mint/bolt*"));
+
+        Assert.True(info.RequiresBlindAuthToken("/v1/mint/bolt11"));
+        Assert.True(info.RequiresBlindAuthToken("/v1/mint/bolt12"));
+        Assert.False(info.RequiresBlindAuthToken("/v1/mint/onchain"));
+    }
+
+    [Fact]
+    public void OnlyTheNamedMethodIsProtected()
+    {
+        var info = InfoWith(("POST", "/v1/mint/*"));
+
+        Assert.True(info.RequiresBlindAuthToken("/v1/mint/quote/bolt11", "POST"));
+        // Reading a quote is a GET and is not covered by a POST entry.
+        Assert.False(info.RequiresBlindAuthToken("/v1/mint/quote/bolt11", "GET"));
+    }
+
+    [Fact]
+    public void PathsAreDataNotPatterns()
+    {
+        // A mint sending regex metacharacters gets them treated literally. Under the old
+        // regex matching "." matched any character and the match was unanchored, so this
+        // would have protected far more than the mint asked for.
+        var info = InfoWith(("POST", "/v1/mint/."));
+
+        Assert.True(info.RequiresBlindAuthToken("/v1/mint/."));
+        Assert.False(info.RequiresBlindAuthToken("/v1/mint/x"));
+    }
+
+    [Fact]
+    public void CatastrophicPatternsAreJustStrings()
+    {
+        // (a+)+$ against a long non-matching input is the classic backtracking bomb.
+        var info = InfoWith(("POST", "/v1/(a+)+$"));
+
+        Assert.False(info.RequiresBlindAuthToken("/v1/" + new string('a', 40) + "!"));
+    }
+
+    [Fact]
+    public void NothingIsProtectedWithoutTheNut()
+    {
+        var info = new MintInfo(JsonSerializer.Deserialize<GetInfoResponse>("{}")!);
+
+        Assert.False(info.RequiresBlindAuthToken("/v1/mint/quote/bolt11"));
+    }
+}

--- a/DotNut/Abstractions/MintInfo.cs
+++ b/DotNut/Abstractions/MintInfo.cs
@@ -1,7 +1,6 @@
 using System.Collections.Concurrent;
 using System.Text.Json;
 using System.Text.Json.Serialization;
-using System.Text.RegularExpressions;
 using DotNut.ApiModels;
 
 namespace DotNut.Abstractions;
@@ -24,17 +23,9 @@ public class MintInfo
                 {
                     _protectedEndpoints = new ProtectedEndpoints
                     {
-                        Cache = new ConcurrentDictionary<string, bool>(),
+                        Cache = new ConcurrentDictionary<(string, string), bool>(),
                         ApiReturn = nut22
-                            .ProtectedEndpoints.Select(o => new ProtectedEndpoint
-                            {
-                                Method = o.Method,
-                                Regex = new Regex(
-                                    o.Path,
-                                    RegexOptions.None,
-                                    TimeSpan.FromMilliseconds(100)
-                                ),
-                            })
+                            .ProtectedEndpoints.Select(ProtectedEndpoint.Parse)
                             .ToArray(),
                     };
                 }
@@ -94,17 +85,23 @@ public class MintInfo
     /// <summary>
     /// Determines if an endpoint requires blind authentication token based on NUT-22
     /// </summary>
-    public bool RequiresBlindAuthToken(string path)
+    /// <param name="path">Request path, e.g. <c>/v1/mint/quote/bolt11</c>.</param>
+    /// <param name="method">
+    /// HTTP method. An entry only protects the method it names, so passing the wrong one, or
+    /// nothing, can send a token where none is needed.
+    /// </param>
+    public bool RequiresBlindAuthToken(string path, string method = "POST")
     {
         if (_protectedEndpoints == null)
             return false;
 
-        if (_protectedEndpoints.Cache.TryGetValue(path, out var cachedValue))
+        var key = (method, path);
+        if (_protectedEndpoints.Cache.TryGetValue(key, out var cachedValue))
             return cachedValue;
 
-        var isProtectedEndpoint = _protectedEndpoints.ApiReturn.Any(e => e.Regex.IsMatch(path));
+        var isProtectedEndpoint = _protectedEndpoints.ApiReturn.Any(e => e.Matches(method, path));
 
-        _protectedEndpoints.Cache[path] = isProtectedEndpoint;
+        _protectedEndpoints.Cache[key] = isProtectedEndpoint;
         return isProtectedEndpoint;
     }
 
@@ -296,14 +293,43 @@ public class ProtectedEndpointSpec
 
 internal class ProtectedEndpoints
 {
-    public ConcurrentDictionary<string, bool> Cache { get; set; } = new();
+    public ConcurrentDictionary<(string Method, string Path), bool> Cache { get; set; } = new();
     public ProtectedEndpoint[] ApiReturn { get; set; } = Array.Empty<ProtectedEndpoint>();
 }
 
+/// <summary>
+/// One entry of a mint's <c>protected_endpoints</c>. NUT-21 and NUT-22 allow exactly two shapes,
+/// and a trailing <c>*</c> is the only wildcard: without it the request path must equal
+/// <see cref="Prefix"/>, with it the path must start with it.
+/// </summary>
 internal class ProtectedEndpoint
 {
     public string Method { get; set; } = string.Empty;
-    public Regex Regex { get; set; }
+    public string Prefix { get; set; } = string.Empty;
+    public bool IsPrefixMatch { get; set; }
+
+    public static ProtectedEndpoint Parse(ProtectedEndpointSpec spec)
+    {
+        var path = spec.Path;
+        var isPrefix = path.EndsWith('*');
+
+        return new ProtectedEndpoint
+        {
+            Method = spec.Method,
+            Prefix = isPrefix ? path[..^1] : path,
+            IsPrefixMatch = isPrefix,
+        };
+    }
+
+    public bool Matches(string method, string path)
+    {
+        if (!string.IsNullOrEmpty(Method) && !Method.Equals(method, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        return IsPrefixMatch ? path.StartsWith(Prefix, StringComparison.Ordinal) : path == Prefix;
+    }
 }
 
 public class WebSocketSupportResult


### PR DESCRIPTION
NUT-21 and NUT-22 were updated to define exactly two path shapes and to forbid regex outright:

> Wallets **MUST** treat mint provided `path` values as untrusted input and use exact or prefix matching only. Never use regex matching on untrusted input.

1. no trailing `*` → the request path must equal `path`
2. trailing `*` → the request path must start with the prefix, and `*` may only be the final character

The patterns changed with it, from `^/v1/mint/.*` to `/v1/mint/*`.

### What was wrong

`MintInfo` compiled the mint's `path` into a `Regex`. Two problems, and the ReDoS one is the less interesting:

- **Wrong matches.** `Regex.IsMatch` is unanchored and metacharacters kept their meaning, so an exact entry like `/v1/auth/blind/mint` also matched `/prefix/v1/auth/blind/mint`, and a `.` in a path matched any character. A mint asking to protect one endpoint got more of them protected, which means tokens attached to requests that never needed them.
- **Untrusted input compiled as code.** There was a 100 ms match timeout, so a backtracking pattern would throw rather than hang, but a `RegexMatchTimeoutException` out of `RequiresBlindAuthToken` is not a good outcome either.

Paths are now compared literally, with the trailing `*` handled explicitly. Tests cover both shapes, a path containing `.`, and `(a+)+$` against a long input.

### HTTP method

`RequiresBlindAuthToken` parsed `method` off each entry, stored it, and then matched on path alone. A `POST`-only entry therefore also claimed the `GET` of the same path. It now takes the method and compares it, defaulting to `POST`.

This changes a public signature, but the default keeps existing single-argument calls compiling.

### Not in this PR

NUT-22 also clarified that `authA` is base64**url** and that padding must be accepted either way. DotNut has no BAT serialisation yet, so there is nothing to fix — worth knowing when that gets built.

---

Unit tests: 116 passing.