### PR TITLE
NUT-11: reject malformed secrets, compare keys by x-coordinate

### DIFF
--- a/DotNut.Tests/Unit/Nut11ValidationTests.cs
+++ b/DotNut.Tests/Unit/Nut11ValidationTests.cs
@@ -1,0 +1,148 @@
+using NBitcoin.Secp256k1;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut11ValidationTests
+{
+    private const string KeyA =
+        "02698c4e2b5f9534cd0687d87513c759790cf829aa5739184a3e3735471fbda904";
+    private const string KeyB =
+        "0379c3e1a2fbd7b1d0f9f0d4a4e5b64e0b4c8fa7d2c0f96a7c5f2b0a9e8d7c6b5a";
+
+    private static P2PKProofSecret Secret(string data, params string[][] tags) =>
+        new()
+        {
+            Data = data,
+            Nonce = "0000000000000000000000000000000000000000000000000000000000000000",
+            Tags = tags,
+        };
+
+    [Theory]
+    // Each tag may appear exactly once.
+    [InlineData("pubkeys")]
+    [InlineData("locktime")]
+    [InlineData("refund")]
+    [InlineData("n_sigs")]
+    [InlineData("n_sigs_refund")]
+    [InlineData("sigflag")]
+    public void RepeatedTagIsMalformed(string tag)
+    {
+        var value = tag switch
+        {
+            "locktime" => "1700000000",
+            "n_sigs" or "n_sigs_refund" => "1",
+            "sigflag" => "SIG_INPUTS",
+            _ => KeyB,
+        };
+
+        var secret = Secret(KeyA, [tag, value], [tag, value]);
+
+        Assert.Contains("appears more than once", Assert.Throws<FormatException>(
+            () => P2PkBuilder.Load(secret)
+        ).Message);
+    }
+
+    [Fact]
+    public void UnknownSigflagIsMalformed()
+    {
+        var secret = Secret(KeyA, ["sigflag", "SIG_EVERYTHING"]);
+
+        Assert.Contains("Unknown sigflag", Assert.Throws<FormatException>(
+            () => P2PkBuilder.Load(secret)
+        ).Message);
+    }
+
+    [Theory]
+    [InlineData("0")]
+    [InlineData("-1")]
+    [InlineData("many")]
+    public void NonPositiveThresholdIsMalformed(string nSigs)
+    {
+        var secret = Secret(KeyA, ["pubkeys", KeyB], ["n_sigs", nSigs]);
+
+        Assert.Contains("positive integer", Assert.Throws<FormatException>(
+            () => P2PkBuilder.Load(secret)
+        ).Message);
+    }
+
+    [Fact]
+    public void ThresholdAboveKeyCountIsMalformed()
+    {
+        // Two keys in the main pathway, three signatures demanded.
+        var secret = Secret(KeyA, ["pubkeys", KeyB], ["n_sigs", "3"]);
+
+        Assert.Contains("pathway has 2 key", Assert.Throws<FormatException>(
+            () => P2PkBuilder.Load(secret)
+        ).Message);
+    }
+
+    [Fact]
+    public void DuplicateKeyInOnePathwayIsMalformed()
+    {
+        // Same x-coordinate, different parity prefix — still the same key.
+        var secret = Secret(KeyA, ["pubkeys", "03" + KeyA[2..]]);
+
+        Assert.Contains("Duplicate pubkey in the main pathway", Assert.Throws<FormatException>(
+            () => P2PkBuilder.Load(secret)
+        ).Message);
+    }
+
+    [Fact]
+    public void DuplicateKeyIsCaughtRegardlessOfCase()
+    {
+        var secret = Secret(KeyA, ["pubkeys", KeyA.ToUpperInvariant()]);
+
+        Assert.Throws<FormatException>(() => P2PkBuilder.Load(secret));
+    }
+
+    [Fact]
+    public void SameKeyInBothPathwaysIsAllowed()
+    {
+        var secret = Secret(
+            KeyA,
+            ["locktime", "1700000000"],
+            ["refund", "03" + KeyA[2..]]
+        );
+
+        var builder = P2PkBuilder.Load(secret);
+        Assert.Single(builder.Pubkeys);
+        Assert.Single(builder.RefundPubkeys!);
+    }
+
+    [Fact]
+    public void MalformedSecretFailsVerificationRatherThanThrowing()
+    {
+        var secret = Secret(KeyA, ["sigflag", "SIG_EVERYTHING"]);
+        var proof = new Proof
+        {
+            Amount = 1,
+            Id = new KeysetId("009a1f293253e41e"),
+            Secret = new StringSecret("x"),
+            C = new PubKey(KeyA),
+            Witness = """{"signatures":["00"]}""",
+        };
+
+        Assert.False(secret.VerifyWitness(proof));
+    }
+
+    [Fact]
+    public void SignsAProofLockedToTheOtherParityOfOurKey()
+    {
+        var privkey = ECPrivKey.Create(
+            Convert.FromHexString(
+                "0000000000000000000000000000000000000000000000000000000000000001"
+            )
+        );
+        var ours = privkey.CreatePubKey().ToHex();
+        // The lock names the same x-coordinate with the opposite parity prefix. A Schnorr
+        // signature from our secret verifies against it, so we must be willing to sign.
+        var flipped = (ours.StartsWith("02") ? "03" : "02") + ours[2..];
+
+        var secret = Secret(flipped);
+        var witness = secret.GenerateWitness("message"u8.ToArray(), [privkey]);
+
+        Assert.NotNull(witness);
+        Assert.Single(witness.Signatures);
+        Assert.True(secret.VerifyWitness("message"u8.ToArray(), witness));
+    }
+}

--- a/DotNut/NUT11/P2PKBuilder.cs
+++ b/DotNut/NUT11/P2PKBuilder.cs
@@ -57,8 +57,115 @@ public class P2PkBuilder
         };
     }
 
+    /// <summary>
+    /// Tags NUT-11 gives meaning to. Each may appear at most once.
+    /// </summary>
+    private static readonly string[] KnownTags =
+    [
+        "pubkeys",
+        "locktime",
+        "refund",
+        "n_sigs",
+        "n_sigs_refund",
+        "sigflag",
+    ];
+
+    /// <summary>
+    /// Checks the NUT-11 well-formedness rules. A secret that breaks any of them makes the
+    /// proof unspendable, so it is rejected rather than interpreted.
+    /// </summary>
+    /// <returns>What is wrong, or null when the secret is well formed.</returns>
+    internal static string? FindMalformation(P2PKProofSecret proofSecret)
+    {
+        var tags = proofSecret.Tags ?? [];
+
+        foreach (var tag in KnownTags)
+        {
+            if (tags.Count(t => t.FirstOrDefault() == tag) > 1)
+            {
+                return $"Tag '{tag}' appears more than once";
+            }
+        }
+
+        var sigFlag = TagValues(tags, "sigflag").FirstOrDefault();
+        if (sigFlag is not null && sigFlag != "SIG_INPUTS" && sigFlag != "SIG_ALL")
+        {
+            return $"Unknown sigflag '{sigFlag}'";
+        }
+
+        string[] mainKeys = [proofSecret.Data, .. TagValues(tags, "pubkeys")];
+        var refundKeys = TagValues(tags, "refund").ToArray();
+
+        // A key may appear in both pathways, but not twice within one.
+        if (HasDuplicate(mainKeys))
+        {
+            return "Duplicate pubkey in the main pathway";
+        }
+        if (HasDuplicate(refundKeys))
+        {
+            return "Duplicate pubkey in the refund pathway";
+        }
+
+        if (FindBadThreshold(tags, "n_sigs", mainKeys.Length) is { } mainError)
+        {
+            return mainError;
+        }
+        if (FindBadThreshold(tags, "n_sigs_refund", refundKeys.Length) is { } refundError)
+        {
+            return refundError;
+        }
+
+        return null;
+    }
+
+    private static string? FindBadThreshold(string[][] tags, string tag, int keyCount)
+    {
+        var raw = TagValues(tags, tag).FirstOrDefault();
+        if (raw is null)
+        {
+            return null;
+        }
+
+        if (!int.TryParse(raw, out var threshold) || threshold < 1)
+        {
+            return $"'{tag}' must be a positive integer, got '{raw}'";
+        }
+
+        return threshold > keyCount
+            ? $"'{tag}' is {threshold} but its pathway has {keyCount} key(s)"
+            : null;
+    }
+
+    private static IEnumerable<string> TagValues(string[][] tags, string tag) =>
+        tags.FirstOrDefault(t => t.FirstOrDefault() == tag)?.Skip(1) ?? [];
+
+    /// <summary>
+    /// Compares keys the way NUT-11 does: by lowercase x-coordinate, ignoring the 02/03 parity
+    /// prefix, since either prefix is spendable by the same Schnorr secret.
+    /// </summary>
+    private static bool HasDuplicate(IReadOnlyCollection<string> keys)
+    {
+        var seen = new HashSet<string>();
+        foreach (var key in keys)
+        {
+            if (!seen.Add(XOnly(key)))
+            {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private static string XOnly(string pubkeyHex) =>
+        pubkeyHex.Length == 66 ? pubkeyHex[2..].ToLowerInvariant() : pubkeyHex.ToLowerInvariant();
+
     public static P2PkBuilder Load(P2PKProofSecret proofSecret)
     {
+        if (FindMalformation(proofSecret) is { } malformation)
+        {
+            throw new FormatException($"Malformed P2PK secret: {malformation}");
+        }
+
         var builder = new P2PkBuilder();
         var primaryPubkey = proofSecret.Data.ToPubKey();
         var pubkeys = proofSecret.Tags?.FirstOrDefault(strings =>

--- a/DotNut/NUT11/P2PKProofSecret.cs
+++ b/DotNut/NUT11/P2PKProofSecret.cs
@@ -107,6 +107,21 @@ public class P2PKProofSecret : Nut10ProofSecret
         throw new InvalidOperationException("Not enough valid keys to sign!");
     }
 
+    /// <summary>
+    /// NUT-11 compares keys by x-coordinate, ignoring the 02/03 parity prefix, because a Schnorr
+    /// signature made with one secret verifies against either form. Matching on the full key
+    /// would refuse to sign a proof locked to the other prefix of a key we hold.
+    /// ECXOnlyPubKey has no value equality, so the 32 bytes are compared directly.
+    /// </summary>
+    private static bool IsAllowed(byte[][] allowedXOnly, ECPubKey candidate)
+    {
+        var x = candidate.ToXOnlyPubKey().ToBytes();
+        return allowedXOnly.Any(allowed => allowed.AsSpan().SequenceEqual(x));
+    }
+
+    private static byte[][] ToXOnlyBytes(IEnumerable<ECPubKey> keys) =>
+        keys.Select(k => k.ToXOnlyPubKey().ToBytes()).ToArray();
+
     private (bool IsValid, P2PKWitness Witness) TrySignPath(
         ECPubKey[] allowedKeys,
         int requiredSignatures,
@@ -114,7 +129,7 @@ public class P2PKProofSecret : Nut10ProofSecret
         byte[] msg
     )
     {
-        var allowedKeysSet = new HashSet<ECPubKey>(allowedKeys);
+        var allowedXOnly = ToXOnlyBytes(allowedKeys);
         var result = new P2PKWitness();
 
         foreach (var privKey in availableKeys)
@@ -122,8 +137,7 @@ public class P2PKProofSecret : Nut10ProofSecret
             if (result.Signatures.Length >= requiredSignatures)
                 break;
 
-            var pubkey = privKey.CreatePubKey();
-            if (allowedKeysSet.Contains(pubkey))
+            if (IsAllowed(allowedXOnly, privKey.CreatePubKey()))
             {
                 var sig = privKey.SignBIP340(msg);
                 result.Signatures = result.Signatures.Append(sig.ToHex()).ToArray();


### PR DESCRIPTION
NUT-11 gained a set of rules (cashubtc/nuts#358) that make a proof **unspendable** rather than merely unusual. None of them were checked, so a secret breaking one was interpreted with whichever value `FirstOrDefault` happened to return:

- a tag (`pubkeys`, `locktime`, `refund`, `n_sigs`, `n_sigs_refund`, `sigflag`) appearing more than once
- `n_sigs` / `n_sigs_refund` that is not a positive integer, or exceeds the number of keys in its pathway
- a `sigflag` other than `SIG_INPUTS` or `SIG_ALL`
- the same key twice within one pathway

`P2PkBuilder.Load` now throws on these. Both verification entry points already wrap their work in try/catch, so a malformed secret surfaces as `VerifyWitness` returning false rather than an exception escaping into caller code.

### Key canonicalisation, and the bug it uncovered

The spec defines key comparison as x-coordinate only, ignoring the `02`/`03` parity prefix and letter case, because a Schnorr signature made with one secret verifies against either form. The same key may still appear in *both* the main and refund pathways — only within one pathway is it a duplicate.

Applying that rule turned up a real bug in signing. `TrySignPath` matched candidate keys against the allowed set by **full** public key:

```csharp
var allowedKeysSet = new HashSet<ECPubKey>(allowedKeys);
...
if (allowedKeysSet.Contains(privKey.CreatePubKey()))
```

So a proof locked to `03<x>` could not be signed with the key we hold as `02<x>`, and `GenerateWitness` threw "Not enough valid keys to sign!" — we refused to spend proofs that were ours. `VerifyPath` already compared x-only, so only the signing side was affected.

There is a regression test for it; on `master` it fails with exactly that exception.

`ECXOnlyPubKey` has no value equality, so the 32 bytes are compared directly rather than through the objects.

### Left alone

The P2BK (NUT-28) blinded path in `GenerateBlindWitness` also matches on full keys, but there the parity handling is deliberate — it tries the tweaked key and its negation as separate branches. Collapsing that to x-only would make the second branch dead code, and it is out of scope here.

---

Unit tests: 125 passing, 16 of them new. All 20 P2PK, P2BK and HTLC integration tests verified against cdk-mintd 0.17.3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of NUT-11 secrets, rejecting malformed tags, signature flags, thresholds, and duplicate keys.
  * Malformed secrets now fail safely with a validation error instead of causing unexpected failures.
  * P2PK signing now works correctly when public-key parity differs.
  * Keys shared across main and refund pathways remain supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->