### PR TITLE
NUT-04/05: method_name and melt options

### DIFF
--- a/DotNut.Tests/Unit/Nut04MethodNameTests.cs
+++ b/DotNut.Tests/Unit/Nut04MethodNameTests.cs
@@ -1,0 +1,64 @@
+using System.Text.Json;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut04MethodNameTests
+{
+    [Theory]
+    // Examples straight from 04.md.
+    [InlineData("bolt11", "Bolt11")]
+    [InlineData("apple-pay", "Apple Pay")]
+    [InlineData("onchain", "Onchain")]
+    [InlineData("onchain_payment_processor", "Onchain Payment Processor")]
+    public void DerivesADisplayNameWhenTheMintSendsNone(string method, string expected)
+    {
+        Assert.Equal(expected, MethodNameFallback.DisplayNameFor(method, null));
+        Assert.Equal(expected, MethodNameFallback.DisplayNameFor(method, ""));
+    }
+
+    [Fact]
+    public void PrefersWhatTheMintSent()
+    {
+        Assert.Equal("Lightning", MethodNameFallback.DisplayNameFor("bolt11", "Lightning"));
+    }
+
+    [Theory]
+    [InlineData("bolt11", true)]
+    [InlineData("onchain-payment_processor", true)]
+    [InlineData("", false)]
+    [InlineData("Bolt11", false)]
+    [InlineData("bolt 11", false)]
+    [InlineData("bolt.11", false)]
+    public void ValidatesTheMethodIdentifier(string method, bool valid)
+    {
+        Assert.Equal(valid, MethodNameFallback.IsValidMethod(method));
+    }
+
+    [Fact]
+    public void MintSettingRoundTrips()
+    {
+        var setting = JsonSerializer.Deserialize<MintMethodSetting>(
+            """{"method":"apple-pay","unit":"usd","method_name":null,"min_amount":1}"""
+        );
+        Assert.NotNull(setting);
+
+        Assert.Null(setting.MethodName);
+        Assert.Equal("Apple Pay", setting.DisplayName);
+
+        // method_name is omitted rather than written as null.
+        Assert.DoesNotContain("method_name", JsonSerializer.Serialize(setting));
+    }
+
+    [Fact]
+    public void MeltSettingCarriesOptions()
+    {
+        var setting = JsonSerializer.Deserialize<MeltMethodSetting>(
+            """{"method":"bolt11","unit":"sat","method_name":"Lightning","options":{"amountless":true}}"""
+        );
+        Assert.NotNull(setting);
+
+        Assert.Equal("Lightning", setting.DisplayName);
+        Assert.NotNull(setting.Options);
+        Assert.True(setting.Options.RootElement.GetProperty("amountless").GetBoolean());
+    }
+}

--- a/DotNut/NUT04/MethodNameFallback.cs
+++ b/DotNut/NUT04/MethodNameFallback.cs
@@ -1,0 +1,38 @@
+using System.Globalization;
+
+namespace DotNut;
+
+public static class MethodNameFallback
+{
+    /// <summary>
+    /// The method identifier a mint may use. NUT-04 restricts it to lowercase ASCII
+    /// alphanumerics, hyphens and underscores, and it must be non-empty.
+    /// </summary>
+    public static bool IsValidMethod(string? method) =>
+        !string.IsNullOrEmpty(method)
+        && method.All(c =>
+            c is >= 'a' and <= 'z' or >= '0' and <= '9' or '-' or '_'
+        );
+
+    /// <summary>
+    /// The name to show for a payment method. Uses what the mint sent, and otherwise derives one
+    /// from the method identifier by turning <c>_</c> and <c>-</c> into spaces and title-casing
+    /// each word, as NUT-04 prescribes: <c>bolt11</c> becomes <c>Bolt11</c>, <c>apple-pay</c>
+    /// becomes <c>Apple Pay</c>.
+    /// </summary>
+    public static string DisplayNameFor(string method, string? methodName)
+    {
+        if (!string.IsNullOrEmpty(methodName))
+        {
+            return methodName;
+        }
+
+        var words = method.Split(['_', '-'], StringSplitOptions.RemoveEmptyEntries);
+        return string.Join(
+            ' ',
+            words.Select(word =>
+                CultureInfo.InvariantCulture.TextInfo.ToTitleCase(word.ToLowerInvariant())
+            )
+        );
+    }
+}

--- a/DotNut/NUT04/MintMethodSetting.cs
+++ b/DotNut/NUT04/MintMethodSetting.cs
@@ -11,6 +11,18 @@ public class MintMethodSetting
     [JsonPropertyName("unit")]
     public string Unit { get; set; }
 
+    /// <summary>
+    /// Human-readable name for the method. Null or absent when the mint does not send one, in
+    /// which case <see cref="DisplayName"/> derives it from <see cref="Method"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("method_name")]
+    public string? MethodName { get; set; }
+
+    /// <inheritdoc cref="MethodNameFallback.DisplayNameFor"/>
+    [JsonIgnore]
+    public string DisplayName => MethodNameFallback.DisplayNameFor(Method, MethodName);
+
     [JsonPropertyName("min_amount")]
     public ulong? Min { get; set; }
 

--- a/DotNut/NUT05/MeltMethodSetting.cs
+++ b/DotNut/NUT05/MeltMethodSetting.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace DotNut;
 
@@ -10,9 +11,26 @@ public class MeltMethodSetting
     [JsonPropertyName("unit")]
     public string Unit { get; set; }
 
+    /// <summary>
+    /// Human-readable name for the method. Null or absent when the mint does not send one, in
+    /// which case <see cref="DisplayName"/> derives it from <see cref="Method"/>.
+    /// </summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("method_name")]
+    public string? MethodName { get; set; }
+
+    /// <inheritdoc cref="MethodNameFallback.DisplayNameFor"/>
+    [JsonIgnore]
+    public string DisplayName => MethodNameFallback.DisplayNameFor(Method, MethodName);
+
     [JsonPropertyName("min_amount")]
     public ulong? Min { get; set; }
 
     [JsonPropertyName("max_amount")]
     public ulong? Max { get; set; }
+
+    /// <summary>Method-specific settings, defined by the method's own NUT.</summary>
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    [JsonPropertyName("options")]
+    public JsonDocument? Options { get; set; }
 }


### PR DESCRIPTION
`method_name` was added to both `MintMethodSetting` and `MeltMethodSetting`, with a fallback the spec spells out for when a mint omits it:

> wallets **SHOULD** derive it from `method` by replacing `_` and `-` with spaces and title-casing each word (e.g. `bolt11` -> `Bolt11`, `apple-pay` -> `Apple Pay`)

`DisplayName` on both settings does that. It matters more than it looks: with custom payment methods now allowed, the identifier is no longer something you would want to show a user directly.

Also:

- `MeltMethodSetting` gained `options`, which `MintMethodSetting` already had
- `MethodNameFallback.IsValidMethod` checks NUT-04's rule for the identifier — non-empty, and only lowercase ASCII alphanumerics, `-` and `_`

`method_name` is omitted from serialisation when unset rather than written as null.

---

Unit tests: 122 passing.