### PR TITLE
NUT-14: allow HTLCs that no pubkey can sign

### DIFF
--- a/DotNut.Tests/Unit/Nut14PreimageOnlyTests.cs
+++ b/DotNut.Tests/Unit/Nut14PreimageOnlyTests.cs
@@ -1,0 +1,59 @@
+using SHA256 = System.Security.Cryptography.SHA256;
+
+namespace DotNut.Tests.Unit;
+
+public class Nut14PreimageOnlyTests
+{
+    private const string Preimage =
+        "0000000000000000000000000000000000000000000000000000000000000000";
+
+    private static HTLCProofSecret PureHashlock()
+    {
+        var hashLock = Convert
+            .ToHexString(SHA256.HashData(Convert.FromHexString(Preimage)))
+            .ToLowerInvariant();
+
+        return new HTLCBuilder { HashLock = hashLock }.Build();
+    }
+
+    [Fact]
+    public void HashlockWithoutPubkeysNeedsNoSignature()
+    {
+        var secret = PureHashlock();
+
+        // No pubkeys tag at all, so nothing to sign with.
+        Assert.Empty(secret.Builder.Pubkeys);
+        Assert.DoesNotContain(secret.Tags ?? [], t => t.FirstOrDefault() == "pubkeys");
+
+        secret.GetAllowedPubkeys(out var requiredSignatures);
+        Assert.Equal(0, requiredSignatures);
+    }
+
+    [Fact]
+    public void PreimageAloneSpendsTheProof()
+    {
+        var secret = PureHashlock();
+        var message = "message"u8.ToArray();
+
+        var witness = secret.GenerateWitness(message, [], Convert.FromHexString(Preimage));
+
+        Assert.NotNull(witness);
+        Assert.Empty(witness.Signatures);
+        Assert.True(secret.VerifyWitness(message, witness));
+    }
+
+    [Fact]
+    public void WrongPreimageDoesNotSpendIt()
+    {
+        var secret = PureHashlock();
+        var message = "message"u8.ToArray();
+
+        var witness = new HTLCWitness
+        {
+            Signatures = [],
+            Preimage = new string('1', 64),
+        };
+
+        Assert.False(secret.VerifyWitness(message, witness));
+    }
+}

--- a/DotNut/NUT11/P2PKBuilder.cs
+++ b/DotNut/NUT11/P2PKBuilder.cs
@@ -9,7 +9,11 @@ public class P2PkBuilder
     public ECPubKey[]? RefundPubkeys { get; set; }
     public int SignatureThreshold { get; set; } = 1;
 
-    public ECPubKey[] Pubkeys { get; set; }
+    /// <summary>
+    /// Keys of the main pathway. Empty for a NUT-14 hashlock with no <c>pubkeys</c> tag, where
+    /// the preimage alone spends the proof.
+    /// </summary>
+    public ECPubKey[] Pubkeys { get; set; } = [];
 
     //SIG_INPUTS, SIG_ALL
     public string? SigFlag { get; set; }


### PR DESCRIPTION
NUT-14 was clarified (cashubtc/nuts#396) to state outright:

> **NOTE:** If the `pubkeys` tag is absent, the preimage alone spends the proof; no signature is required.

Verification already coped — `GetAllowedPubkeys` reports zero required signatures for an empty key set, and `VerifyPath` is satisfied by zero signatures. The problem was earlier: such a secret could not be constructed at all.

`P2PkBuilder.Pubkeys` is a non-nullable `ECPubKey[]` that was never initialised, so

```csharp
new HTLCBuilder { HashLock = hash }.Build();
```

threw `ArgumentNullException` out of `Pubkeys.ToArray()` before it got anywhere near the hashlock. `Clone` and `BuildBlinded` had the same problem.

Defaulting the property to an empty array is the whole fix. A pure hashlock now builds, yields a witness carrying only the preimage, and verifies — and a wrong preimage still fails.

Worth noting the test that would otherwise be missing: with no keys involved, the only thing standing between the proof and a spend is the preimage check, so it is the one path where getting the hashlock comparison wrong would be silent.

---

Unit tests: 112 passing, 3 new. HTLC and P2PK integration tests verified against cdk-mintd 0.17.3.